### PR TITLE
Add help url to editor script

### DIFF
--- a/com.vrcfury.vrcfury/Runtime/VF/Model/VRCFury.cs
+++ b/com.vrcfury.vrcfury/Runtime/VF/Model/VRCFury.cs
@@ -8,7 +8,7 @@ using VF.Model.Feature;
 using Action = VF.Model.StateAction.Action;
 
 namespace VF.Model {
-
+    [HelpURL("https://github.com/VRCFury/VRCFury#readme")]
     public class VRCFury : VRCFuryComponent {
         [HideInInspector]
         public VRCFuryConfig config = new VRCFuryConfig();


### PR DESCRIPTION
A very simple change which sets the help url attribute for unity
<img width="139" alt="image" src="https://github.com/VRCFury/VRCFury/assets/13484789/911397c3-eacf-46fe-a788-ebbf79a5372e">
