### PR TITLE
Do not add a default WD fix animation if WD fix is set to disabled (addressing Issue #25)

### DIFF
--- a/com.vrcfury.vrcfury/Editor/VF/Feature/FixWriteDefaultsBuilder.cs
+++ b/com.vrcfury.vrcfury/Editor/VF/Feature/FixWriteDefaultsBuilder.cs
@@ -83,8 +83,7 @@ namespace VF.Feature {
                 applyToUnmanagedLayers = true;
                 useWriteDefaults = true;
             } else {
-                applyToUnmanagedLayers = false;
-                useWriteDefaults = shouldBeOnIfWeAreNotInControl;
+                return;
             }
             
             Debug.Log("VRCFury is fixing write defaults "


### PR DESCRIPTION
Hey there!

I understand that this is probably a dirty fix as I did not have time to fully understand all the intricacies of VRCFury yet.

This is a follow-up to our discussion in Discord where my gesture layer gets broken by the WD fix default animation that is being created in the first FX layer.

Given that the description of the Fix Write Defaults Features specifically says that setting to to disabled means: "Don't try to fix anything and don't warn even if it looks broken" I think it should indeed not try to fix anything at all and that includes creating that default animation. We should assume that someone using that option knows what they are doing and will manage their animation states themselves.

This change simply makes it quit out of the WD Fix code when it is set to disabled so we do indeed not change anything. I understand that this change might not be an elegant way of doing this and might have implications in other areas that I am not yet aware of, but just wanted to at least share this change as that is what I will be using on my local version for the moment in order to be able to keep working until a better fix becomes available. I hope it sheds some more light on what was giving me grief.

Best regards,
Krazen