### PR TITLE
Add the option to target channel 1 with the SPS shader.

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -55,3 +55,5 @@ For more information, please refer to <https://unlicense.org>
   * Added global parameters for Toggles
 * nullstalgia
   * Added option for Toggles to use momentary push buttons
+* Tayou
+  * SPS: Added support for wider light ranges (ranges other than 0.4X)

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -57,3 +57,4 @@ For more information, please refer to <https://unlicense.org>
   * Added option for Toggles to use momentary push buttons
 * Tayou
   * SPS: Added support for wider light ranges (ranges other than 0.4X)
+  * SPS: Added support for Channel switching

--- a/com.vrcfury.vrcfury/Editor/VF/Inspector/VRCFuryHapticPlugEditor.cs
+++ b/com.vrcfury.vrcfury/Editor/VF/Inspector/VRCFuryHapticPlugEditor.cs
@@ -22,6 +22,8 @@ namespace VF.Inspector {
             var configureTps = serializedObject.FindProperty("configureTps");
             var configureSps = serializedObject.FindProperty("configureSps");
             
+            var addChannelToggle = serializedObject.FindProperty("addChannelToggle");
+            
             container.Add(new PropertyField(serializedObject.FindProperty("name"), "Name in connected apps"));
             
             var autoMesh = serializedObject.FindProperty("autoRenderer");
@@ -83,6 +85,21 @@ namespace VF.Inspector {
             }, configureTps));
             
             container.Add(VRCFuryEditorUtils.Prop(configureSps, "Auto-configure SPS Penetration System (ALPHA, USE WITH CAUTION)"));
+            container.Add(VRCFuryEditorUtils.RefreshOnChange(() => {
+                var c = new VisualElement();
+                if (configureSps.boolValue) {
+                    c.Add(VRCFuryEditorUtils.Prop(serializedObject.FindProperty("defaultChannel"), "Default Channel to use (Use 0 if you don't know what this is)"));
+                    c.Add(VRCFuryEditorUtils.Prop(addChannelToggle, "Auto Generate Channel Toggle"));
+                }
+                return c;
+            }, configureSps));
+            container.Add(VRCFuryEditorUtils.RefreshOnChange(() => {
+                var c = new VisualElement();
+                if (addChannelToggle.boolValue) {
+                    c.Add(VRCFuryEditorUtils.Prop(serializedObject.FindProperty("channelToggleMenuPath"), "Menu Path"));
+                }
+                return c;
+            }, addChannelToggle));
 
             var adv = new Foldout {
                 text = "Advanced",

--- a/com.vrcfury.vrcfury/Runtime/VF/Component/VRCFuryHapticPlug.cs
+++ b/com.vrcfury.vrcfury/Runtime/VF/Component/VRCFuryHapticPlug.cs
@@ -14,6 +14,9 @@ namespace VF.Component {
         public bool unitsInMeters = false;
         public bool configureTps = false;
         public bool configureSps = false;
+        public bool defaultChannel = false;
+        public bool addChannelToggle = false;
+        public string channelToggleMenuPath = "";
         public GuidTexture2d configureTpsMask = null;
         public List<Renderer> configureTpsMesh = new List<Renderer>();
 

--- a/com.vrcfury.vrcfury/SPS/sps_funcs.cginc
+++ b/com.vrcfury.vrcfury/SPS/sps_funcs.cginc
@@ -4,6 +4,7 @@
 
 float _SPS_Length;
 float _SPS_BakedLength;
+float _SPS_Channel;
 
 // SPS Penetration Shader
 void sps_apply(inout float3 vertex, inout float3 normal, uint vertexId)
@@ -25,7 +26,7 @@ void sps_apply(inout float3 vertex, inout float3 normal, uint vertexId)
 	float3 frontNormal;
 	float entranceAngle;
 	float targetAngle;
-	bool found = sps_search(rootPos, isRing, frontNormal, entranceAngle, targetAngle);
+	bool found = sps_search(rootPos, isRing, frontNormal, entranceAngle, targetAngle, _SPS_Channel);
 	if (!found) return;
 
 	float orfDistance = length(rootPos);

--- a/com.vrcfury.vrcfury/SPS/sps_props.cginc
+++ b/com.vrcfury.vrcfury/SPS/sps_props.cginc
@@ -1,3 +1,5 @@
 _SPS_Length("Length of Penetrator Model", Float) = 0
 _SPS_BakedLength("Length of Penetrator Model when baked", Float) = 0
 _SPS_Bake("Baked resting position", 2D) = "white" {}
+[Enum(Channel 0, 0, Channel 1, 1)]_SPS_Channel("Channel", Float) = 0
+

--- a/com.vrcfury.vrcfury/SPS/sps_search.cginc
+++ b/com.vrcfury.vrcfury/SPS/sps_search.cginc
@@ -1,10 +1,10 @@
 #include "UnityShaderVariables.cginc"
 
 #define SPS_PI float(3.14159265359)
-bool sps_isType(float range, float target) { return abs(range - target) < 0.005; }
-bool sps_isHole(float range) { return sps_isType(range, 0.41); }
-bool sps_isRing(float range) { return sps_isType(range, 0.42); }
-bool sps_isFront(float range) { return sps_isType(range, 0.45); }
+bool sps_isType(float range, float target) { return abs(fmod(range, 0.1) - target) < 0.005; }
+bool sps_isHole(float range) { return sps_isType(range, 0.01); }
+bool sps_isRing(float range) { return sps_isType(range, 0.02); }
+bool sps_isFront(float range) { return sps_isType(range, 0.05); }
 float3 sps_toLocal(float3 v) { return mul(unity_WorldToObject, float4(v, 1)); }
 float3 sps_toWorld(float3 v) { return mul(unity_ObjectToWorld, float4(v, 1)); }
 // https://forum.unity.com/threads/point-light-in-v-f-shader.499717/#post-3250460


### PR DESCRIPTION
channel 1 was a severely underused and undocumented feature in DPS.
https://gist.github.com/TayouVR/aad7f8b6d83264b379d90e5100653a76#channel-1-advanced
this adds support for it to the shader. Currently there is no (easy) way for any end users to actually use it, as you need to animate the new shader property. 
I am leaving this as draft right now as I plan to add a bit of UI for this. Maybe also for the sockets while I'm at it (I've been meaning to do this for a while actually)

also: will rebase this on master when other PR is merged