### PR TITLE
Support retargeting Physbone Colliders

### DIFF
--- a/com.vrcfury.vrcfury/Editor/VF/Feature/ArmatureLinkBuilder.cs
+++ b/com.vrcfury.vrcfury/Editor/VF/Feature/ArmatureLinkBuilder.cs
@@ -106,7 +106,7 @@ namespace VF.Feature {
                     var avatarBone = mergeBone.Item2;
                     FailIfComponents(propBone);
                     UpdatePhysbones(propBone, avatarBone);
-                    UpdatePhysboneColliders(propBone, avatarBone, scalingRequired, scalingFactor);
+                    UpdatePhysboneColliders(propBone, avatarBone, scalingRequired, scalingFactor, keepBoneOffsets);
                     UpdateConstraints(propBone, avatarBone);
                     boneMapping[propBone.transform] = avatarBone.transform;
                     mover.AddDirectRewrite(propBone, avatarBone);
@@ -274,18 +274,23 @@ namespace VF.Feature {
             }
         }
         
-        private void UpdatePhysboneColliders(GameObject propBone, GameObject avatarBone, bool scalingRequired, float scalingFactor) {
+        private void UpdatePhysboneColliders(GameObject propBone, GameObject avatarBone, bool scalingRequired, float scalingFactor, bool keepBoneOffsets) {
             foreach (var collider in avatarObject.GetComponentsInSelfAndChildren<VRCPhysBoneCollider>()) {
                 var root = collider.GetRootTransform();
                 if (propBone.transform == root) {
-                    if (scalingRequired) {
-                        var scaleBone = new GameObject("vrcf_" + uniqueModelNum + "_" + propBone.name);
-                        scaleBone.transform.localScale = Vector3.one * scalingFactor;
-                        scaleBone.transform.SetParent(avatarBone.transform, false);
-                        collider.rootTransform = scaleBone.transform;
+                    if (scalingRequired || keepBoneOffsets) {
+                        var childBone = new GameObject("vrcf_" + uniqueModelNum + "_" + propBone.name);
+                        if (scalingRequired) {
+                            childBone.transform.localScale = Vector3.one * scalingFactor;
+                        }
+                        childBone.transform.SetParent(avatarBone.transform, false);
+                        if (keepBoneOffsets) {
+                            childBone.transform.position = propBone.transform.position;
+                            childBone.transform.rotation = propBone.transform.rotation;
+                        }
+                        collider.rootTransform = childBone.transform;
                     } else {
                         collider.rootTransform = avatarBone.transform;
-
                     }
                 }
             }

--- a/com.vrcfury.vrcfury/Editor/VF/Feature/ArmatureLinkBuilder.cs
+++ b/com.vrcfury.vrcfury/Editor/VF/Feature/ArmatureLinkBuilder.cs
@@ -106,7 +106,7 @@ namespace VF.Feature {
                     var avatarBone = mergeBone.Item2;
                     FailIfComponents(propBone);
                     UpdatePhysbones(propBone, avatarBone);
-                    UpdatePhysboneColliders(propBone, avatarBone);
+                    UpdatePhysboneColliders(propBone, avatarBone, scalingRequired, scalingFactor);
                     UpdateConstraints(propBone, avatarBone);
                     boneMapping[propBone.transform] = avatarBone.transform;
                     mover.AddDirectRewrite(propBone, avatarBone);
@@ -274,11 +274,19 @@ namespace VF.Feature {
             }
         }
         
-        private void UpdatePhysboneColliders(GameObject propBone, GameObject avatarBone) {
+        private void UpdatePhysboneColliders(GameObject propBone, GameObject avatarBone, bool scalingRequired, float scalingFactor) {
             foreach (var collider in avatarObject.GetComponentsInSelfAndChildren<VRCPhysBoneCollider>()) {
                 var root = collider.GetRootTransform();
                 if (propBone.transform == root) {
-                    collider.rootTransform = avatarBone.transform;
+                    if (scalingRequired) {
+                        var scaleBone = new GameObject("vrcf_" + uniqueModelNum + "_" + propBone.name);
+                        scaleBone.transform.localScale = Vector3.one * scalingFactor;
+                        scaleBone.transform.SetParent(avatarBone.transform, false);
+                        collider.rootTransform = scaleBone.transform;
+                    } else {
+                        collider.rootTransform = avatarBone.transform;
+
+                    }
                 }
             }
         }

--- a/com.vrcfury.vrcfury/Editor/VF/Feature/ArmatureLinkBuilder.cs
+++ b/com.vrcfury.vrcfury/Editor/VF/Feature/ArmatureLinkBuilder.cs
@@ -157,7 +157,6 @@ namespace VF.Feature {
                     } else {
                         FailIfComponents(propBone);
                         UpdatePhysbones(propBone, avatarBone);
-                        UpdatePhysboneColliders(propBone, avatarBone);
                     }
 
                     // Move the object

--- a/com.vrcfury.vrcfury/Editor/VF/Feature/ArmatureLinkBuilder.cs
+++ b/com.vrcfury.vrcfury/Editor/VF/Feature/ArmatureLinkBuilder.cs
@@ -106,6 +106,7 @@ namespace VF.Feature {
                     var avatarBone = mergeBone.Item2;
                     FailIfComponents(propBone);
                     UpdatePhysbones(propBone, avatarBone);
+                    UpdatePhysboneColliders(propBone, avatarBone);
                     UpdateConstraints(propBone, avatarBone);
                     boneMapping[propBone.transform] = avatarBone.transform;
                     mover.AddDirectRewrite(propBone, avatarBone);
@@ -156,6 +157,7 @@ namespace VF.Feature {
                     } else {
                         FailIfComponents(propBone);
                         UpdatePhysbones(propBone, avatarBone);
+                        UpdatePhysboneColliders(propBone, avatarBone);
                     }
 
                     // Move the object
@@ -268,6 +270,23 @@ namespace VF.Feature {
                             "Physbone " + physbonePath + " points to a bone that is going to" +
                             " stop existing because it is being merged into the avatar using Armature Link." +
                             " If this physbone needs to exist, it should be placed on a new child object of the linked bone.");
+                    }
+                }
+            }
+        }
+        
+        private void UpdatePhysboneColliders(GameObject propBone, GameObject avatarBone) {
+            foreach (var collider in avatarObject.GetComponentsInSelfAndChildren<VRCPhysBoneCollider>()) {
+                var root = collider.GetRootTransform();
+                if (propBone.transform == root) {
+                    if (model.physbonesOnAvatarBones) {
+                        collider.rootTransform = avatarBone.transform;
+                    } else {
+                        var colliderPath = clipBuilder.GetPath(collider.gameObject);
+                        throw new VRCFBuilderException(
+                            "Physbone Collider " + colliderPath + " points to a bone that is going to" +
+                            " stop existing because it is being merged into the avatar using Armature Link." +
+                            " If this collider needs to exist, it should be placed on a new child object of the linked bone.");
                     }
                 }
             }

--- a/com.vrcfury.vrcfury/Editor/VF/Feature/ArmatureLinkBuilder.cs
+++ b/com.vrcfury.vrcfury/Editor/VF/Feature/ArmatureLinkBuilder.cs
@@ -279,15 +279,7 @@ namespace VF.Feature {
             foreach (var collider in avatarObject.GetComponentsInSelfAndChildren<VRCPhysBoneCollider>()) {
                 var root = collider.GetRootTransform();
                 if (propBone.transform == root) {
-                    if (model.physbonesOnAvatarBones) {
-                        collider.rootTransform = avatarBone.transform;
-                    } else {
-                        var colliderPath = clipBuilder.GetPath(collider.gameObject);
-                        throw new VRCFBuilderException(
-                            "Physbone Collider " + colliderPath + " points to a bone that is going to" +
-                            " stop existing because it is being merged into the avatar using Armature Link." +
-                            " If this collider needs to exist, it should be placed on a new child object of the linked bone.");
-                    }
+                    collider.rootTransform = avatarBone.transform;
                 }
             }
         }

--- a/com.vrcfury.vrcfury/Editor/VF/Feature/ArmatureLinkBuilder.cs
+++ b/com.vrcfury.vrcfury/Editor/VF/Feature/ArmatureLinkBuilder.cs
@@ -287,6 +287,8 @@ namespace VF.Feature {
                         if (keepBoneOffsets) {
                             childBone.transform.position = propBone.transform.position;
                             childBone.transform.rotation = propBone.transform.rotation;
+                            var lossyScale = propBone.transform.localScale;
+                            childBone.transform.localScale *= Mathf.Max(lossyScale.x, lossyScale.y, lossyScale.z);
                         }
                         collider.rootTransform = childBone.transform;
                     } else {

--- a/com.vrcfury.vrcfury/Editor/VF/Feature/ArmatureLinkBuilder.cs
+++ b/com.vrcfury.vrcfury/Editor/VF/Feature/ArmatureLinkBuilder.cs
@@ -280,15 +280,12 @@ namespace VF.Feature {
                 if (propBone.transform == root) {
                     if (scalingRequired || keepBoneOffsets) {
                         var childBone = new GameObject("vrcf_" + uniqueModelNum + "_" + propBone.name);
-                        if (scalingRequired) {
+                        if (keepBoneOffsets) { // reparenting solves scaling requirement
+                            childBone.transform.SetParent(propBone.transform, false);
+                            childBone.transform.SetParent(avatarBone.transform, true);
+                        } else { // only scaling required
                             childBone.transform.localScale = Vector3.one * scalingFactor;
-                        }
-                        childBone.transform.SetParent(avatarBone.transform, false);
-                        if (keepBoneOffsets) {
-                            childBone.transform.position = propBone.transform.position;
-                            childBone.transform.rotation = propBone.transform.rotation;
-                            var lossyScale = propBone.transform.lossyScale;
-                            childBone.transform.localScale *= Mathf.Max(lossyScale.x, lossyScale.y, lossyScale.z);
+                            childBone.transform.SetParent(avatarBone.transform, false);
                         }
                         collider.rootTransform = childBone.transform;
                     } else {

--- a/com.vrcfury.vrcfury/Editor/VF/Feature/ArmatureLinkBuilder.cs
+++ b/com.vrcfury.vrcfury/Editor/VF/Feature/ArmatureLinkBuilder.cs
@@ -287,7 +287,7 @@ namespace VF.Feature {
                         if (keepBoneOffsets) {
                             childBone.transform.position = propBone.transform.position;
                             childBone.transform.rotation = propBone.transform.rotation;
-                            var lossyScale = propBone.transform.localScale;
+                            var lossyScale = propBone.transform.lossyScale;
                             childBone.transform.localScale *= Mathf.Max(lossyScale.x, lossyScale.y, lossyScale.z);
                         }
                         collider.rootTransform = childBone.transform;


### PR DESCRIPTION
Currently Physbone Colliders are not being retargeted when armature linking.
This pull request adds support for retargeting of a colliders root bone to the corresponding avatar bone.

```
The changes made in this contribution are free and unencumbered software
released into the public domain.

Anyone is free to copy, modify, publish, use, compile, sell, or
distribute this software, either in source code form or as a compiled
binary, for any purpose, commercial or non-commercial, and by any
means.

In jurisdictions that recognize copyright laws, the author or authors
of this software dedicate any and all copyright interest in the
software to the public domain. We make this dedication for the benefit
of the public at large and to the detriment of our heirs and
successors. We intend this dedication to be an overt act of
relinquishment in perpetuity of all present and future rights to this
software under copyright law.

THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND,
EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF
MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT.
IN NO EVENT SHALL THE AUTHORS BE LIABLE FOR ANY CLAIM, DAMAGES OR
OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE,
ARISING FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR
OTHER DEALINGS IN THE SOFTWARE.

For more information, please refer to <https://unlicense.org>
```