### PR TITLE
Allow slider toggle to function with Use Global Parameter

### DIFF
--- a/com.vrcfury.vrcfury/Editor/VF/Feature/ToggleBuilder.cs
+++ b/com.vrcfury.vrcfury/Editor/VF/Feature/ToggleBuilder.cs
@@ -18,7 +18,7 @@ public class ToggleBuilder : FeatureBuilder<Toggle> {
     private List<VFAState> exclusiveTagTriggeringStates = new List<VFAState>();
     private VFABool param;
     private AnimationClip restingClip;
-    
+
     private const string menuPathTooltip = "Menu Path is where you'd like the toggle to be located in the menu. This is unrelated"
         + " to the menu filenames -- simply enter the title you'd like to use. If you'd like the toggle to be in a submenu, use slashes. For example:\n\n"
         + "If you want the toggle to be called 'Shirt' in the root menu, you'd put:\nShirt\n\n"
@@ -41,14 +41,23 @@ public class ToggleBuilder : FeatureBuilder<Toggle> {
         var fx = GetFx();
         var layerName = model.name;
         var layer = fx.NewLayer(layerName);
+        var param = model.name;
+        bool usePrefixOnParam = true;
+
+        if (model.useGlobalParam && model.globalParam != null && model.paramOverride == null) {
+            model.paramOverride = model.globalParam;
+            param = model.paramOverride;
+            usePrefixOnParam = false;
+        }
 
         var off = layer.NewState("Off");
         var on = layer.NewState("On");
         var x = fx.NewFloat(
-            model.name,
+            param,
             synced: true,
             saved: model.saved,
-            def: model.defaultOn ? model.defaultSliderValue : 0
+            def: model.defaultOn ? model.defaultSliderValue : 0,
+            usePrefix: usePrefixOnParam
         );
         manager.GetMenu().NewMenuSlider(
             model.name,
@@ -114,7 +123,7 @@ public class ToggleBuilder : FeatureBuilder<Toggle> {
             param = boolParam;
             onCase = boolParam.IsTrue();
         }
-        
+
         if (model.separateLocal) {
             var isLocal = fx.IsLocal().IsTrue();
             Apply(fx, layer, off, onCase.And(isLocal.Not()), "On Remote", model.state, model.transitionStateIn, model.transitionStateOut, physBoneResetter);
@@ -139,7 +148,7 @@ public class ToggleBuilder : FeatureBuilder<Toggle> {
             }
         }
     }
-    
+
     private void Apply(
         ControllerManager fx,
         VFALayer layer,
@@ -211,7 +220,7 @@ public class ToggleBuilder : FeatureBuilder<Toggle> {
      [FeatureBuilderAction(FeatureOrder.CollectToggleExclusiveTags)]
      public void ApplyExclusiveTags() {
         if (exclusiveTagTriggeringStates.Count == 0) return;
-        
+
         var fx = GetFx();
         var allOthersOffCondition = fx.Always();
 
@@ -346,7 +355,7 @@ public class ToggleBuilder : FeatureBuilder<Toggle> {
                     prop.serializedObject.ApplyModifiedProperties();
                 });
             }
-            
+
             if (exclusiveOffStateProp != null) {
                 advMenu.AddItem(new GUIContent("This is Exclusive Off State"), exclusiveOffStateProp.boolValue, () => {
                     exclusiveOffStateProp.boolValue = !exclusiveOffStateProp.boolValue;
@@ -360,7 +369,7 @@ public class ToggleBuilder : FeatureBuilder<Toggle> {
                     prop.serializedObject.ApplyModifiedProperties();
                 });
             }
-            
+
             if (enableDriveGlobalParamProp != null) {
                 advMenu.AddItem(new GUIContent("Drive a Global Parameter"), enableDriveGlobalParamProp.boolValue, () => {
                     enableDriveGlobalParamProp.boolValue = !enableDriveGlobalParamProp.boolValue;
@@ -402,7 +411,7 @@ public class ToggleBuilder : FeatureBuilder<Toggle> {
         });
         button.style.flexGrow = 0;
         flex.Add(button);
-        
+
         renderBody(content);
 
         if (resetPhysboneProp != null) {
@@ -444,7 +453,7 @@ public class ToggleBuilder : FeatureBuilder<Toggle> {
             }
             return c;
         }, sliderProp, defaultOnProp));
-        
+
         if (enableIconProp != null) {
             content.Add(VRCFuryEditorUtils.RefreshOnChange(() => {
                 var c = new VisualElement();
@@ -502,7 +511,7 @@ public class ToggleBuilder : FeatureBuilder<Toggle> {
 
                 if (!simpleOutTransitionProp.boolValue)
                     c.Add(VRCFuryEditorUtils.Prop(prop.FindPropertyRelative("localTransitionStateOut"), "Local Trans. Out"));
-                    
+
             }
             return c;
         }, separateLocalProp, hasTransitionProp, simpleOutTransitionProp));


### PR DESCRIPTION
Fixes: when combining the **Use Global Parameter** and **Use Slider Wheel** options in a Toggle feature the toggle would still generate a prefixed parameter, ignoring the global parameter set.

---

The changes made in this contribution are free and unencumbered software released into the public domain.

Anyone is free to copy, modify, publish, use, compile, sell, or distribute this software, either in source code form or as a compiled binary, for any purpose, commercial or non-commercial, and by any means.

In jurisdictions that recognize copyright laws, the author or authors of this software dedicate any and all copyright interest in the software to the public domain. We make this dedication for the benefit of the public at large and to the detriment of our heirs and successors. We intend this dedication to be an overt act of relinquishment in perpetuity of all present and future rights to this software under copyright law.

THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.

For more information, please refer to <https://unlicense.org>