### PR TITLE
rewrite Build in PlayMode with Awake for better & simpler compatibility with Av3Emu and GestureManager

### DIFF
--- a/com.vrcfury.vrcfury/CONTRIBUTING.md
+++ b/com.vrcfury.vrcfury/CONTRIBUTING.md
@@ -57,3 +57,5 @@ For more information, please refer to <https://unlicense.org>
   * Added option for Toggles to use momentary push buttons
 * Ximmer-VR
   * Made Toggle sliders work with global parameters
+* anatawa12
+  * Rewrote Build in PlayMode for better & simpler compatibility with Av3Emu and GestureManager

--- a/com.vrcfury.vrcfury/Editor/VF/PlayModeTrigger.cs
+++ b/com.vrcfury.vrcfury/Editor/VF/PlayModeTrigger.cs
@@ -1,17 +1,11 @@
 using System;
 using System.IO;
-using System.Linq;
-using System.Reflection;
 using UnityEditor;
-using UnityEngine;
-using UnityEngine.SceneManagement;
 using VF.Builder;
 using VF.Builder.Exceptions;
 using VF.Component;
 using VF.Inspector;
 using VF.Menu;
-using VF.Model;
-using VRC.Dynamics;
 using VRC.SDK3.Avatars.Components;
 using VRC.SDKBase.Editor.BuildPipeline;
 using Object = UnityEngine.Object;
@@ -19,56 +13,84 @@ using Object = UnityEngine.Object;
 namespace VF {
     [InitializeOnLoad]
     public class PlayModeTrigger : IVRCSDKPostprocessAvatarCallback {
-        private static double lastRescan = 0;
-        private static string AboutToUploadKey = "vrcf_vrcAboutToUpload";
-        private static string tmpDir;
-        public int callbackOrder => int.MaxValue;
-        public void OnPostprocessAvatar() {
-            EditorPrefs.SetFloat(AboutToUploadKey, Now());
-        }
-
-        private static float Now() {
-            return (float)EditorApplication.timeSinceStartup;
-        }
-
-        private static bool activeNow = false;
-        static PlayModeTrigger() {
-            SceneManager.sceneLoaded += OnSceneLoaded;
+        static PlayModeTrigger()
+        {
+            VRCFuryComponent.AwakeOrStart += AwakeOrStart;
             EditorApplication.playModeStateChanged += OnPlayModeStateChanged;
-            EditorApplication.update += () => {
-                var now = Now();
-                if (now > lastRescan + 0.5) {
-                    lastRescan = now;
-                    Rescan();
-                }
-            };
         }
 
-        private static void OnPlayModeStateChanged(PlayModeStateChange state) {
-            var aboutToUploadTime = EditorPrefs.GetFloat(AboutToUploadKey, 0);
-            var now = Now();
-            activeNow = false;
-            var problyUploading = aboutToUploadTime <= now && aboutToUploadTime > Now() - 10;
-            if (state == PlayModeStateChange.ExitingEditMode) {
-                if (!problyUploading && PlayModeMenuItem.Get()) {
-                    var rootObjects = VFGameObject.GetRoots();
-                    VRCFPrefabFixer.Fix(rootObjects);
-                }
+        // We want to apply VRCFury on Awake to perform before Av3Emu or GestureManager
+        // but when apply VRCFury for newly enabled avatars on Awake, editor may crashes.
+        // As a workaround, apply on Awake until scene load is finished and apply on Start
+        // for newly enabled avatars.
+        private static bool _applyOnAwake = true;
 
-                tmpDir = null;
-            } else if (state == PlayModeStateChange.EnteredPlayMode) {
-                if (problyUploading) {
-                    EditorPrefs.DeleteKey(AboutToUploadKey);
-                    return;
+        private static void AwakeOrStart(bool isAwake, VRCFuryComponent component)
+        {
+            if (!PlayModeMenuItem.Get()) return; // manually disabled
+            if (isAwake != _applyOnAwake) return;
+
+            var avatar = component.gameObject.GetComponentInParent<VRCAvatarDescriptor>();
+            if (avatar != null)
+            {
+                VFGameObject avatarGameObject = avatar.gameObject;
+                if (ContainsAnyPrefabs(avatarGameObject)) return;
+
+                var builder = new VRCFuryBuilder();
+                builder.SafeRun(avatarGameObject);
+                VRCFuryBuilder.StripAllVrcfComponents(avatarGameObject);
+            }
+            else
+            {
+                // even if it's not in avatar, process haptic socket and plug
+                if (ContainsAnyPrefabs(component.gameObject)) return;
+
+                switch (component)
+                {
+                    case VRCFuryHapticSocket socket:
+                        socket.Upgrade();
+                        VRCFExceptionUtils.ErrorDialogBoundary(() => {
+                            VRCFuryHapticSocketEditor.Bake(socket, onlySenders: true);
+                        });
+                        Object.DestroyImmediate(socket);
+                        break;
+                    case VRCFuryHapticPlug plug:
+                        plug.Upgrade();
+                        VRCFExceptionUtils.ErrorDialogBoundary(() => {
+                            var mutableManager = new MutableManager(TempDir);
+                            VRCFuryHapticPlugEditor.Bake(plug, onlySenders: true, mutableManager: mutableManager);
+                        });
+                        Object.DestroyImmediate(plug);
+                        break;
                 }
-                EditorPrefs.DeleteKey(AboutToUploadKey);
-                activeNow = true;
-                Rescan();
             }
         }
 
-        private static void OnSceneLoaded(Scene scene, LoadSceneMode mode) {
-            Rescan();
+        private static void OnPlayModeStateChanged(PlayModeStateChange state)
+        {
+            switch (state)
+            {
+                case PlayModeStateChange.EnteredEditMode:
+                    _applyOnAwake = true;
+                    break;
+                case PlayModeStateChange.ExitingEditMode:
+                    if (PlayModeMenuItem.Get()) {
+                        var rootObjects = VFGameObject.GetRoots();
+                        VRCFPrefabFixer.Fix(rootObjects);
+                    }
+
+                    _tmpDir = null;
+                    _probablyUploading = null;
+                    break;
+                case PlayModeStateChange.EnteredPlayMode:
+                    _applyOnAwake = false;
+                    // force compute ProbablyUploading before removing AboutToUploadKey
+                    var _ = ProbablyUploading;
+                    EditorPrefs.DeleteKey(AboutToUploadKey);
+                    break;
+                case PlayModeStateChange.ExitingPlayMode:
+                    break;
+            }
         }
 
         // This should absolutely always be false in play mode, but we check just in case
@@ -80,217 +102,54 @@ namespace VF {
             }
             return false;
         }
-
-        private static void Rescan() {
-            if (!Application.isPlaying) return;
-            if (!PlayModeMenuItem.Get()) return;
-            if (!activeNow) return;
-
-            if (tmpDir == null) {
-                var tmpDirParent = TmpFilePackage.GetPath() + "/PlayMode";
-                VRCFuryAssetDatabase.DeleteFolder(tmpDirParent);
-                tmpDir = $"{tmpDirParent}/{DateTime.Now.ToString("yyyyMMdd-HHmmss")}";
-                Directory.CreateDirectory(tmpDir);
-            }
-
-            var builder = new VRCFuryBuilder();
-            var oneChanged = false;
-            foreach (var root in VFGameObject.GetRoots()) {
-                foreach (var avatar in root.GetComponentsInSelfAndChildren<VRCAvatarDescriptor>()) {
-                    var obj = avatar.owner();
-                    if (!obj.activeInHierarchy) continue;
-                    if (ContainsAnyPrefabs(obj)) continue;
-                    if (IsWithinAv3EmulatorClone(obj)) continue;
-                    if (obj.GetComponentsInSelfAndChildren<VRCFuryTest>().Length > 0) {
-                        continue;
-                    }
-                    if (!VRCFuryBuilder.ShouldRun(obj)) continue;
-                    builder.SafeRun(obj);
-                    VRCFuryBuilder.StripAllVrcfComponents(obj);
-                    oneChanged = true;
-                    RestartPhysbones(obj);
-                }
-                foreach (var socket in root.GetComponentsInSelfAndChildren<VRCFuryHapticSocket>()) {
-                    var obj = socket.owner();
-                    if (!obj.activeInHierarchy) continue;
-                    if (ContainsAnyPrefabs(obj)) continue;
-                    if (IsWithinAv3EmulatorClone(obj)) continue;
-                    socket.Upgrade();
-                    VRCFExceptionUtils.ErrorDialogBoundary(() => {
-                        VRCFuryHapticSocketEditor.Bake(socket, onlySenders: true);
-                    });
-                    Object.DestroyImmediate(socket);
-                    RestartPhysbones(obj);
-                }
-                foreach (var plug in root.GetComponentsInSelfAndChildren<VRCFuryHapticPlug>()) {
-                    var obj = plug.owner();
-                    if (!obj.activeInHierarchy) continue;
-                    if (ContainsAnyPrefabs(obj)) continue;
-                    if (IsWithinAv3EmulatorClone(obj)) continue;
-                    plug.Upgrade();
-                    VRCFExceptionUtils.ErrorDialogBoundary(() => {
-                        var mutableManager = new MutableManager(tmpDir);
-                        VRCFuryHapticPlugEditor.Bake(plug, onlySenders: true, mutableManager: mutableManager);
-                    });
-                    Object.DestroyImmediate(plug);
-                    RestartPhysbones(obj);
-                }
-            }
-
-            if (oneChanged) {
-                RestartVrcsdk();
-                RestartAv3Emulator();
-                RestartGestureManager();
-                RestartAudiolink();
-            }
-        }
-
-        private static bool IsAv3EmulatorClone(VFGameObject obj) {
-            return obj.name.Contains("(ShadowClone)")
-                   || obj.name.Contains("(MirrorReflection)");
-        }
         
-        private static bool IsWithinAv3EmulatorClone(VFGameObject obj) {
-            return obj.GetSelfAndAllParents().Any(IsAv3EmulatorClone);
+
+        #region probablyUploading
+        private const string AboutToUploadKey = "vrcf_vrcAboutToUpload";
+        private static bool? _probablyUploading = null;
+        private static float Now() => (float)EditorApplication.timeSinceStartup;
+
+        public int callbackOrder => int.MaxValue;
+
+        public void OnPostprocessAvatar()
+        {
+            SessionState.SetFloat(AboutToUploadKey, Now());
         }
 
-        private static void DestroyAllOfType(string typeStr) {
-            var type = ReflectionUtils.GetTypeFromAnyAssembly(typeStr);
-            if (type == null) return;
-            foreach (var runtime in Object.FindObjectsOfType(type)) {
-                Object.DestroyImmediate(runtime);
+        private static bool ProbablyUploading
+        {
+            get
+            {
+                if (_probablyUploading is bool probablyUploading) return probablyUploading;
+                var aboutToUploadTime = SessionState.GetFloat(AboutToUploadKey, 0);
+                var now = Now();
+                probablyUploading = aboutToUploadTime <= now && aboutToUploadTime > now - 10;
+                _probablyUploading = probablyUploading;
+                return probablyUploading;
+            }
+        }
+        #endregion
+
+        #region TempDir
+
+        private static string _tmpDir;
+
+        private static string TempDir
+        {
+            get
+            {
+                if (_tmpDir == null)
+                {
+                    var tmpDirParent = TmpFilePackage.GetPath() + "/PlayMode";
+                    VRCFuryAssetDatabase.DeleteFolder(tmpDirParent);
+                    _tmpDir = $"{tmpDirParent}/{DateTime.Now.ToString("yyyyMMdd-HHmmss")}";
+                    Directory.CreateDirectory(_tmpDir);
+                }
+
+                return _tmpDir;
             }
         }
 
-        private static void ClearField(object obj, string fieldStr) {
-            var field = obj.GetType().GetField(fieldStr);
-            if (field == null) return;
-            var value = field.GetValue(obj);
-            if (value == null) return;
-            var clear = value.GetType().GetMethod("Clear");
-            if (clear == null) return;
-            clear.Invoke(value, new object[]{});
-        }
-
-        private static void RestartVrcsdk() {
-            try {
-                var initClass = ReflectionUtils.GetTypeFromAnyAssembly("VRC.SDK3.Avatars.AvatarDynamicsSetup");
-                if (initClass == null) return;
-                var initTrigger = initClass.GetMethod("Trigger_OnInitialize",
-                    BindingFlags.Static | BindingFlags.Public | BindingFlags.NonPublic);
-                if (initTrigger == null) return;
-                var initPhysBone = initClass.GetMethod("PhysBone_OnInitialize",
-                    BindingFlags.Static | BindingFlags.Public | BindingFlags.NonPublic);
-                if (initPhysBone == null) return;
-                
-                Debug.Log($"Restarting VRCSDK components ...");
-
-                foreach (var receiver in Object.FindObjectsOfType<ContactReceiver>()) {
-                    receiver.paramAccess = null;
-                    initTrigger.Invoke(null, new object[] { receiver });
-                }
-                foreach (var physbone in Object.FindObjectsOfType<VRCPhysBoneBase>()) {
-                    physbone.param_Angle = null;
-                    physbone.param_Stretch = null;
-                    physbone.param_IsGrabbed = null;
-                    initPhysBone.Invoke(null, new object[] { physbone });
-                }
-            } catch (Exception e) {
-                Debug.LogException(e);
-                EditorUtility.DisplayDialog(
-                    "VRCFury",
-                    "VRCFury was unable to reload the VRCSDK after making changes to the avatar." +
-                    " Because of this, testing in play mode may not be 100% correct." +
-                    " Report this on https://vrcfury.com/discord\n\n" + e.Message,
-                    "Ok"
-                );
-            }
-        }
-
-        private static void RestartAv3Emulator() {
-            try {
-                var av3EmulatorType = ReflectionUtils.GetTypeFromAnyAssembly("Lyuma.Av3Emulator.Runtime.LyumaAv3Emulator");
-                if (av3EmulatorType == null) av3EmulatorType = ReflectionUtils.GetTypeFromAnyAssembly("LyumaAv3Emulator");
-                if (av3EmulatorType == null) return;
-                
-                Debug.Log("Restarting av3emulator ...");
-                
-                DestroyAllOfType("Lyuma.Av3Emulator.Runtime.LyumaAv3Runtime");
-                DestroyAllOfType("LyumaAv3Runtime");
-                DestroyAllOfType("Lyuma.Av3Emulator.Runtime.LyumaAv3Menu");
-                DestroyAllOfType("Lyuma.Av3Emulator.Runtime.GestureManagerAv3Menu");
-
-                var restartField = av3EmulatorType.GetField("RestartEmulator");
-                if (restartField == null) throw new Exception("Failed to find RestartEmulator field");
-                var emulators = Object.FindObjectsOfType(av3EmulatorType);
-                foreach (var emulator in emulators) {
-                    ClearField(emulator, "runtimes");
-                    ClearField(emulator, "forceActiveRuntimes");
-                    ClearField(emulator, "scannedAvatars");
-                    restartField.SetValue(emulator, true);
-                }
-
-                foreach (var root in VFGameObject.GetRoots()) {
-                    if (IsAv3EmulatorClone(root)) {
-                        root.Destroy();
-                    }
-                }
-            } catch (Exception e) {
-                Debug.LogException(e);
-                EditorUtility.DisplayDialog(
-                    "VRCFury",
-                    "VRCFury detected Av3Emulator, but was unable to reload it after making changes to the avatar." +
-                    " Because of this, testing with the emulator may not be correct." +
-                    " Report this on https://vrcfury.com/discord\n\n" + e.Message,
-                    "Ok"
-                );
-            }
-        }
-
-        private static void RestartGestureManager() {
-            try {
-                var gmType = ReflectionUtils.GetTypeFromAnyAssembly("BlackStartX.GestureManager.GestureManager");
-                if (gmType == null) return;
-                Debug.Log("Restarting gesture manager ...");
-                foreach (var gm in Object.FindObjectsOfType(gmType).OfType<UnityEngine.Component>()) {
-                    if (gm.gameObject.activeSelf) {
-                        gm.gameObject.SetActive(false);
-                        gm.gameObject.SetActive(true);
-                    }
-
-                    if (Selection.activeGameObject == gm.gameObject) {
-                        Selection.activeGameObject = null;
-                        EditorApplication.delayCall += () => Selection.activeGameObject = gm.gameObject;
-                    }
-                }
-            } catch (Exception e) {
-                Debug.LogException(e);
-                EditorUtility.DisplayDialog(
-                    "VRCFury",
-                    "VRCFury detected GestureManager, but was unable to reload it after making changes to the avatar." +
-                    " Because of this, testing with the emulator may not be correct." +
-                    " Report this on https://vrcfury.com/discord\n\n" + e.Message,
-                    "Ok"
-                );
-            }
-        }
-        
-        private static void RestartAudiolink() {
-            var alComponentType = ReflectionUtils.GetTypeFromAnyAssembly("VRCAudioLink.AudioLink");
-            if (alComponentType == null) return;
-            foreach (var gm in Object.FindObjectsOfType(alComponentType).OfType<UnityEngine.Component>()) {
-                Debug.Log("Restarting AudioLink ...");
-                if (gm.gameObject.activeSelf) {
-                    gm.gameObject.SetActive(false);
-                    gm.gameObject.SetActive(true);
-                }
-            }
-        }
-
-        private static void RestartPhysbones(VFGameObject obj) {
-            foreach (var physbone in obj.GetComponentsInSelfAndChildren<VRCPhysBoneBase>()) {
-                physbone.InitTransforms(true);
-            }
-        }
+        #endregion
     }
 }

--- a/com.vrcfury.vrcfury/Runtime/VF/Component/VRCFuryActivator.cs
+++ b/com.vrcfury.vrcfury/Runtime/VF/Component/VRCFuryActivator.cs
@@ -1,0 +1,31 @@
+using System;
+using UnityEngine;
+
+namespace VF.Component {
+    [AddComponentMenu("")]
+    public abstract class VRCFuryActivator : VRCFuryComponent {
+#if UNITY_EDITOR
+        private void Awake()
+        {
+            UnityEditor.EditorApplication.delayCall += () => DestroyIfNeeded();
+        }
+
+        private void Start()
+        {
+            if (!this) return;
+            if (DestroyIfNeeded()) return;
+        }
+
+        private bool DestroyIfNeeded()
+        {
+            var shouldDestroy = !UnityEditor.EditorApplication.isPlaying ||
+                                UnityEditor.EditorUtility.IsPersistent(this);
+            if (!shouldDestroy) return false;
+
+            Debug.Log("Destroying ApplyOnPlayActivator in Start");
+            DestroyImmediate(this);
+            return true;
+        }
+#endif
+    }
+}

--- a/com.vrcfury.vrcfury/Runtime/VF/Component/VRCFuryActivator.cs.meta
+++ b/com.vrcfury.vrcfury/Runtime/VF/Component/VRCFuryActivator.cs.meta
@@ -1,0 +1,3 @@
+fileFormatVersion: 2
+guid: 3563708e4f15490bbec1e181a1655373
+timeCreated: 1691507833

--- a/com.vrcfury.vrcfury/Runtime/VF/Component/VRCFuryComponent.cs
+++ b/com.vrcfury.vrcfury/Runtime/VF/Component/VRCFuryComponent.cs
@@ -14,19 +14,13 @@ namespace VF.Component {
 
         #region ApplyOnPlay
 #if UNITY_EDITOR
-        // parameter: (is awake, component)
+        // parameter: (component)
         /// this field is public to allow access from Editor module but this is not part of public API.
-        public static Action<bool, VRCFuryComponent> AwakeOrStart;
-        private void Awake()
-        {
-            if (!UnityEditor.EditorApplication.isPlaying || this == null) return;
-            AwakeOrStart?.Invoke(true, this);
-        }
-
+        public static Action<VRCFuryComponent> StartCallback;
         private void Start()
         {
             if (!UnityEditor.EditorApplication.isPlaying || this == null) return;
-            AwakeOrStart?.Invoke(false, this);
+            StartCallback?.Invoke(this);
         }
 #endif
         #endregion

--- a/com.vrcfury.vrcfury/Runtime/VF/Component/VRCFuryComponent.cs
+++ b/com.vrcfury.vrcfury/Runtime/VF/Component/VRCFuryComponent.cs
@@ -5,11 +5,31 @@ using UnityEditor;
 using UnityEngine;
 
 namespace VF.Component {
+    [DefaultExecutionOrder(-19999)] // run before av3emu and modular avatar
     public abstract class VRCFuryComponent : MonoBehaviour, ISerializationCallbackReceiver, IVrcfEditorOnly {
         [SerializeField]
         private int version = -1;
 
         [NonSerialized] public GameObject gameObjectOverride;
+
+        #region ApplyOnPlay
+#if UNITY_EDITOR
+        // parameter: (is awake, component)
+        /// this field is public to allow access from Editor module but this is not part of public API.
+        public static Action<bool, VRCFuryComponent> AwakeOrStart;
+        private void Awake()
+        {
+            if (!UnityEditor.EditorApplication.isPlaying || this == null) return;
+            AwakeOrStart?.Invoke(true, this);
+        }
+
+        private void Start()
+        {
+            if (!UnityEditor.EditorApplication.isPlaying || this == null) return;
+            AwakeOrStart?.Invoke(false, this);
+        }
+#endif
+        #endregion
 
         public new GameObject gameObject {
             get {


### PR DESCRIPTION
On the Av3Emu dev discord, we hear not working well with VRCFury. 
I assume the reason why not working is restarting av3emulator in VRCFury is not working well.

To improve compatibility, I rewrite way to boot Av3Emu with Awake.
The Awake method is used in many non destructive tools such as AvatarOptimizer (until v1.0.x) or ModularAvatar.

This method is compatible with both Av3Emu and (latest) GestureManager.