### PR TITLE
make all GogoLoco parameters Global

### DIFF
--- a/com.vrcfury.vrcfury/Prefabs/GogoLoco/GogoLoco All (VRCFury).prefab
+++ b/com.vrcfury.vrcfury/Prefabs/GogoLoco/GogoLoco All (VRCFury).prefab
@@ -89,6 +89,10 @@ MonoBehaviour:
         globalParams:
         - Go/Float
         - Go/Stationary
+        - Go/Locomotion
+        - Go/Jump&Fall
+        - Go/CrouchIdle
+        - Go/ProneIdle
         allNonsyncedAreGlobal: 0
         ignoreSaved: 0
         toggleParam: 

--- a/com.vrcfury.vrcfury/Prefabs/GogoLoco/GogoLoco Beyond (VRCFury).prefab
+++ b/com.vrcfury.vrcfury/Prefabs/GogoLoco/GogoLoco Beyond (VRCFury).prefab
@@ -98,6 +98,10 @@ MonoBehaviour:
         globalParams:
         - Go/Float
         - Go/Stationary
+        - Go/Locomotion
+        - Go/Jump&Fall
+        - Go/CrouchIdle
+        - Go/ProneIdle
         allNonsyncedAreGlobal: 0
         ignoreSaved: 0
         toggleParam: 


### PR DESCRIPTION
This preserves the GogoLoco saved settings between uploads that change the amount of VRCFury components there are.