### PR TITLE
Modify preprocess check to check for initialization state

### DIFF
--- a/com.vrcfury.vrcfury/Editor/VF/VrcHooks/PreuploadHook.cs
+++ b/com.vrcfury.vrcfury/Editor/VF/VrcHooks/PreuploadHook.cs
@@ -4,6 +4,7 @@ using System.Linq;
 using UnityEditor;
 using UnityEngine;
 using VF.Builder;
+using VF.Component;
 using VRC.SDK3.Avatars.Components;
 using VRC.SDKBase.Editor.BuildPipeline;
 using Object = UnityEngine.Object;
@@ -15,12 +16,15 @@ namespace VF.VrcHooks {
 
         public bool OnPreprocessAvatar(GameObject _vrcCloneObject) {
             if (EditorApplication.isPlaying) {
-                EditorUtility.DisplayDialog(
-                    "VRCFury",
-                    "Something is causing VRCFury to build while play mode is still initializing. This may cause unity to crash!!\n\n" +
-                    "If you use Av3Emulator, consider using Gesture Manager instead, or uncheck 'Run Preprocess Avatar Hook' on the Av3 Emulator Control object.",
-                    "Ok"
-                );
+                VRCFuryComponent[] components = GameObject.FindObjectsOfType<VRCFuryComponent>();
+                if(components.Any(x => x.isActiveAndEnabled && !x.Initialized)) {
+                    EditorUtility.DisplayDialog(
+                        "VRCFury",
+                        "Something is causing VRCFury to build while play mode is still initializing. This may cause unity to crash!!\n\n" +
+                        "If you use Av3Emulator, consider using Gesture Manager instead, or uncheck 'Run Preprocess Avatar Hook' on the Av3 Emulator Control object.",
+                        "Ok"
+                    );
+                }
             }
             
             VFGameObject vrcCloneObject = _vrcCloneObject;

--- a/com.vrcfury.vrcfury/Editor/VF/VrcHooks/PreuploadHook.cs
+++ b/com.vrcfury.vrcfury/Editor/VF/VrcHooks/PreuploadHook.cs
@@ -4,7 +4,6 @@ using System.Linq;
 using UnityEditor;
 using UnityEngine;
 using VF.Builder;
-using VF.Component;
 using VRC.SDK3.Avatars.Components;
 using VRC.SDKBase.Editor.BuildPipeline;
 using Object = UnityEngine.Object;
@@ -16,15 +15,12 @@ namespace VF.VrcHooks {
 
         public bool OnPreprocessAvatar(GameObject _vrcCloneObject) {
             if (EditorApplication.isPlaying) {
-                VRCFuryComponent[] components = GameObject.FindObjectsOfType<VRCFuryComponent>();
-                if(components.Any(x => !x.Initialized)) {
-                    EditorUtility.DisplayDialog(
-                        "VRCFury",
-                        "Something is causing VRCFury to build while play mode is still initializing. This may cause unity to crash!!\n\n" +
-                        "If you use Av3Emulator, consider using Gesture Manager instead, or uncheck 'Run Preprocess Avatar Hook' on the Av3 Emulator Control object.",
-                        "Ok"
-                    );
-                }
+                EditorUtility.DisplayDialog(
+                    "VRCFury",
+                    "Something is causing VRCFury to build while play mode is still initializing. This may cause unity to crash!!\n\n" +
+                    "If you use Av3Emulator, consider using Gesture Manager instead, or uncheck 'Run Preprocess Avatar Hook' on the Av3 Emulator Control object.",
+                    "Ok"
+                );
             }
             
             VFGameObject vrcCloneObject = _vrcCloneObject;

--- a/com.vrcfury.vrcfury/Editor/VF/VrcHooks/PreuploadHook.cs
+++ b/com.vrcfury.vrcfury/Editor/VF/VrcHooks/PreuploadHook.cs
@@ -17,7 +17,7 @@ namespace VF.VrcHooks {
         public bool OnPreprocessAvatar(GameObject _vrcCloneObject) {
             if (EditorApplication.isPlaying) {
                 VRCFuryComponent[] components = GameObject.FindObjectsOfType<VRCFuryComponent>();
-                if(components.Any(x => x.isActiveAndEnabled && !x.Initialized)) {
+                if(components.Any(x => !x.Initialized)) {
                     EditorUtility.DisplayDialog(
                         "VRCFury",
                         "Something is causing VRCFury to build while play mode is still initializing. This may cause unity to crash!!\n\n" +

--- a/com.vrcfury.vrcfury/Runtime/VF/Component/VRCFuryComponent.cs
+++ b/com.vrcfury.vrcfury/Runtime/VF/Component/VRCFuryComponent.cs
@@ -5,6 +5,7 @@ using UnityEditor;
 using UnityEngine;
 
 namespace VF.Component {
+    [DefaultExecutionOrder(10000)]
     public abstract class VRCFuryComponent : MonoBehaviour, ISerializationCallbackReceiver, IVrcfEditorOnly {
         public bool Initialized;
         private void Awake() {

--- a/com.vrcfury.vrcfury/Runtime/VF/Component/VRCFuryComponent.cs
+++ b/com.vrcfury.vrcfury/Runtime/VF/Component/VRCFuryComponent.cs
@@ -5,13 +5,7 @@ using UnityEditor;
 using UnityEngine;
 
 namespace VF.Component {
-    [DefaultExecutionOrder(10000)]
     public abstract class VRCFuryComponent : MonoBehaviour, ISerializationCallbackReceiver, IVrcfEditorOnly {
-        public bool Initialized;
-        private void Awake() {
-            Initialized = true;
-        }
-
         [SerializeField]
         private int version = -1;
 

--- a/com.vrcfury.vrcfury/Runtime/VF/Component/VRCFuryComponent.cs
+++ b/com.vrcfury.vrcfury/Runtime/VF/Component/VRCFuryComponent.cs
@@ -6,6 +6,11 @@ using UnityEngine;
 
 namespace VF.Component {
     public abstract class VRCFuryComponent : MonoBehaviour, ISerializationCallbackReceiver, IVrcfEditorOnly {
+        public bool Initialized;
+        private void Start() {
+            Initialized = true;
+        }
+
         [SerializeField]
         private int version = -1;
 

--- a/com.vrcfury.vrcfury/Runtime/VF/Component/VRCFuryComponent.cs
+++ b/com.vrcfury.vrcfury/Runtime/VF/Component/VRCFuryComponent.cs
@@ -7,7 +7,7 @@ using UnityEngine;
 namespace VF.Component {
     public abstract class VRCFuryComponent : MonoBehaviour, ISerializationCallbackReceiver, IVrcfEditorOnly {
         public bool Initialized;
-        private void Start() {
+        private void Awake() {
             Initialized = true;
         }
 

--- a/com.vrcfury.vrcfury/Runtime/VF/Component/VRCFuryInitializedTester.cs
+++ b/com.vrcfury.vrcfury/Runtime/VF/Component/VRCFuryInitializedTester.cs
@@ -1,0 +1,12 @@
+﻿using UnityEngine;
+
+namespace VF.Component
+{
+    [DefaultExecutionOrder(10000)]
+    public class VRCFuryInitializedTester : MonoBehaviour {
+        public static bool initialized = false;
+        private void Awake() {
+            initialized = true;
+        }
+    } 
+}

--- a/com.vrcfury.vrcfury/Runtime/VF/Component/VRCFuryInitializedTester.cs.meta
+++ b/com.vrcfury.vrcfury/Runtime/VF/Component/VRCFuryInitializedTester.cs.meta
@@ -1,0 +1,3 @@
+﻿fileFormatVersion: 2
+guid: a675336e8c1644d1b719029fefae001d
+timeCreated: 1692789493


### PR DESCRIPTION
To continue the conversation from #77, we're now working on implementing this initializing in Start behaviour (see [here](https://github.com/lyuma/Av3Emulator/pull/127)). In the meantime, I'd like to change this check to more accurately reflect whether the components are only in play mode, or also actually busy initializing.

This check fails on the current version of the emulator on main, and displays the popup as expected, but the new version that calls the callback after two frames, doesn't fail this check.