### PR TITLE
When copying assets, also copy their asset labels.

### DIFF
--- a/com.vrcfury.vrcfury/Editor/VF/Builder/MutableManager.cs
+++ b/com.vrcfury.vrcfury/Editor/VF/Builder/MutableManager.cs
@@ -117,6 +117,8 @@ namespace VF.Builder {
                     copyClip.WriteProxyBinding(originalClip);
                 }
 
+                VRCFuryAssetDatabase.CopyAssetLabelsFromOriginal(original, copy);
+
                 originalToMutable[original] = copy;
                 mutableToOriginal[copy] = original;
                 return true;
@@ -307,6 +309,7 @@ namespace VF.Builder {
             var copy = SafeInstantiate(original);
             copy.name = original.name;
             VRCFuryAssetDatabase.SaveAsset(copy, tmpDir, $"{copy.name} for {owner.name}");
+            VRCFuryAssetDatabase.CopyAssetLabelsFromOriginal(original, copy);
             mutableOwners[copy] = owner;
             originalToMutable[(original, owner)] = copy;
             return copy;

--- a/com.vrcfury.vrcfury/Editor/VF/Builder/VRCFuryAssetDatabase.cs
+++ b/com.vrcfury.vrcfury/Editor/VF/Builder/VRCFuryAssetDatabase.cs
@@ -66,6 +66,11 @@ namespace VF.Builder {
             AssetDatabase.CreateAsset(obj, fullPath);
         }
 
+        public static void CopyAssetLabelsFromOriginal(Object original, Object copy) {
+            var originalLabels = AssetDatabase.GetLabels(original);
+            AssetDatabase.SetLabels(copy, originalLabels);
+        }
+
         private static bool assetEditing = false;
         public static void WithAssetEditing(Action go) {
             if (!assetEditing) {


### PR DESCRIPTION
Should address https://github.com/VRCFury/VRCFury/issues/107

In order to successfully copy the asset labels, we have to save them after the copy has been saved in the asset database. The rationale behind the changes is to call the new `VRCFuryAssetDatabase.CopyAssetLabelsFromOriginal` function after objects returned by `SafeInstantiate` have been saved to the asset database.

To test this, I used a Kobodal avatar with VRCFury blendshape optimization on. The body mesh has been baked using a modified version of the VF Goo bake tool that also assigns the saved mesh the `VFGoo1 UV2 Baked 1` `VFGoo1 Normals Baked 1` labels. The editor test copy mesh retained the asset labels, ableit I had to move the mesh out of the Packages folder to see them in the inspector. The goo shader verification was able to see that the mesh has the bake asset labels on it during 'Build & Test' and 'Build & Publish' after VRCFury had done its pass on the avatar.

If anything needs to be changed, let me know.

```
The changes made in this contribution are free and unencumbered software
released into the public domain.

Anyone is free to copy, modify, publish, use, compile, sell, or
distribute this software, either in source code form or as a compiled
binary, for any purpose, commercial or non-commercial, and by any
means.

In jurisdictions that recognize copyright laws, the author or authors
of this software dedicate any and all copyright interest in the
software to the public domain. We make this dedication for the benefit
of the public at large and to the detriment of our heirs and
successors. We intend this dedication to be an overt act of
relinquishment in perpetuity of all present and future rights to this
software under copyright law.

THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND,
EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF
MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT.
IN NO EVENT SHALL THE AUTHORS BE LIABLE FOR ANY CLAIM, DAMAGES OR
OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE,
ARISING FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR
OTHER DEALINGS IN THE SOFTWARE.

For more information, please refer to <https://unlicense.org>
```