### PR TITLE
Bugfix: Fix DirectTreeOptimizer for clips with partial keyframes

### DIFF
--- a/com.vrcfury.vrcfury/CONTRIBUTING.md
+++ b/com.vrcfury.vrcfury/CONTRIBUTING.md
@@ -61,6 +61,7 @@ For more information, please refer to <https://unlicense.org>
   * Improvements to VRCFury/Av3Emu compatibility
 * Morghus
   * Created numerous setup prefabs
+  * Fix DirectTreeOptimizer for clips with partial keyframes
 * nullstalgia
   * Added option for Toggles to use momentary push buttons
   * Prevented SPS toggle from disabling SPS autorig physbone

--- a/com.vrcfury.vrcfury/Editor/VF/Service/ClipBuilderService.cs
+++ b/com.vrcfury.vrcfury/Editor/VF/Service/ClipBuilderService.cs
@@ -168,12 +168,22 @@ namespace VF.Service {
             
             foreach (var (binding,curve) in clip.GetAllCurves()) {
                 if (curve.IsFloat) {
+                    var first = true;
                     foreach (var key in curve.FloatCurve.keys) {
-                        (key.time == 0 ? startClip : endClip).SetConstant(binding, key.value);
+                        if (first) {
+                            startClip.SetConstant(binding, key.value);
+                            first = false;
+                        }
+                        endClip.SetConstant(binding, key.value);
                     }
                 } else {
+                    var first = true;
                     foreach (var key in curve.ObjectCurve) {
-                        (key.time == 0 ? startClip : endClip).SetConstant(binding, key.value);
+                        if (first) {
+                            startClip.SetConstant(binding, key.value);
+                            first = false;
+                        }
+                        endClip.SetConstant(binding, key.value);
                     }
                 }
             }


### PR DESCRIPTION
When animating for example the rotation of an object, it's possible to skip the "end" keyframe on some of the properties and Unity uses the value of the first keyframe for the rest of the curve.

For the Direct Tree Optimizer, the end clip is calculated from the curves, however, it does currently not take into account those clips that only have a "start" keyframe and no "end" keyframe.

This change looks at the curves and if there's only one keyframe, it copies the value of the "start" clip to the "end" clip.

Example clip that would have been broken (notice the missing keyframes at the end of the clip):
![image](https://github.com/VRCFury/VRCFury/assets/140460527/2665f464-3db9-4918-9b55-498417bdf740)

Example clip that works:
![image](https://github.com/VRCFury/VRCFury/assets/140460527/be5ca7bf-2126-4a5d-8ef7-146c0d4cef33)

```
The changes made in this contribution are free and unencumbered software
released into the public domain.

Anyone is free to copy, modify, publish, use, compile, sell, or
distribute this software, either in source code form or as a compiled
binary, for any purpose, commercial or non-commercial, and by any
means.

In jurisdictions that recognize copyright laws, the author or authors
of this software dedicate any and all copyright interest in the
software to the public domain. We make this dedication for the benefit
of the public at large and to the detriment of our heirs and
successors. We intend this dedication to be an overt act of
relinquishment in perpetuity of all present and future rights to this
software under copyright law.

THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND,
EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF
MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT.
IN NO EVENT SHALL THE AUTHORS BE LIABLE FOR ANY CLAIM, DAMAGES OR
OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE,
ARISING FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR
OTHER DEALINGS IN THE SOFTWARE.

For more information, please refer to <https://unlicense.org>
```