### PR TITLE
SPS: Slightly colour legacy DPS tip light to workaround light 4 bug / light sorting issues

### DIFF
--- a/com.vrcfury.vrcfury/Editor/VF/Feature/BakeHapticPlugsBuilder.cs
+++ b/com.vrcfury.vrcfury/Editor/VF/Feature/BakeHapticPlugsBuilder.cs
@@ -83,7 +83,10 @@ namespace VF.Feature {
                         if (EditorUserBuildSettings.activeBuildTarget != BuildTarget.Android) {
                             var light = tip.AddComponent<Light>();
                             light.type = LightType.Point;
-                            light.color = Color.black;
+                            // Unity prioritises coloured over black when sorting unity_LightColor
+                            // Use a slight colour to have unity sort the tip light ahead of
+                            // other orifice lights to avoid the light 4 bug
+                            light.color = new Color(1f/255f, 1f/255f, 1f/255f);
                             light.range = 0.49f;
                             light.shadows = LightShadows.None;
                             light.renderMode = LightRenderMode.ForceVertex;


### PR DESCRIPTION
Unity prioritises coloured lights over pure black when sorting `unity_LightColor`
Use a slight colour to have unity sort the tip light ahead of other orifice lights, hopefully avoiding the light 4 bug corrupting intensity.

```
The changes made in this contribution are free and unencumbered software
released into the public domain.

Anyone is free to copy, modify, publish, use, compile, sell, or
distribute this software, either in source code form or as a compiled
binary, for any purpose, commercial or non-commercial, and by any
means.

In jurisdictions that recognize copyright laws, the author or authors
of this software dedicate any and all copyright interest in the
software to the public domain. We make this dedication for the benefit
of the public at large and to the detriment of our heirs and
successors. We intend this dedication to be an overt act of
relinquishment in perpetuity of all present and future rights to this
software under copyright law.

THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND,
EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF
MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT.
IN NO EVENT SHALL THE AUTHORS BE LIABLE FOR ANY CLAIM, DAMAGES OR
OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE,
ARISING FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR
OTHER DEALINGS IN THE SOFTWARE.

For more information, please refer to <https://unlicense.org>
```