### PR TITLE
SPS: Implement scaling of DPS tip light intensity

### DIFF
--- a/com.vrcfury.vrcfury/CONTRIBUTING.md
+++ b/com.vrcfury.vrcfury/CONTRIBUTING.md
@@ -47,6 +47,8 @@ For more information, please refer to <https://unlicense.org>
 
 ## Special Thanks to the contributors!
 
+* AirGamer
+  * Added scaling of legacy DPS tip light intensity
 * anatawa12
   * Improvements to VRCFury/Av3Emu compatibility
 * CobaltSpace

--- a/com.vrcfury.vrcfury/Editor/VF/Feature/BakeHapticPlugsBuilder.cs
+++ b/com.vrcfury.vrcfury/Editor/VF/Feature/BakeHapticPlugsBuilder.cs
@@ -22,6 +22,7 @@ namespace VF.Feature {
         [VFAutowired] private readonly RestingStateBuilder restingState;
         [VFAutowired] private readonly HapticAnimContactsService _hapticAnimContactsService;
         [VFAutowired] private readonly ForceStateInAnimatorService _forceStateInAnimatorService;
+        [VFAutowired] private readonly ScalePropertyCompensationService scaleCompensationService;
 
         [FeatureBuilderAction(FeatureOrder.BakeHapticPlugs)]
         public void Apply() {
@@ -88,6 +89,8 @@ namespace VF.Feature {
                             light.shadows = LightShadows.None;
                             light.renderMode = LightRenderMode.ForceVertex;
                             light.intensity = worldLength;
+
+                            dpsTipToDo.Add(light);
                         }
 
                         if (tipLightOnClip == null) {
@@ -132,6 +135,7 @@ namespace VF.Feature {
             public IList<string> spsBlendshapes;
         }
         private List<SpsRewriteToDo> spsRewritesToDo = new List<SpsRewriteToDo>();
+        private List<Light> dpsTipToDo = new List<Light>();
 
         [FeatureBuilderAction(FeatureOrder.HapticsAnimationRewrites)]
         public void ApplySpsRewrites() {
@@ -206,5 +210,11 @@ namespace VF.Feature {
             }
         }
 
+        [FeatureBuilderAction(FeatureOrder.DpsTipScaleFix)]
+        public void ApplyDpsTipScale() {
+            foreach (var light in dpsTipToDo)
+                scaleCompensationService.AddScaledPorperties(light.gameObject,
+                    new[] { (AnimationUtility.CalculateTransformPath(light.transform, avatarObject.transform), typeof(Light), "m_Intensity", (object)light.intensity) });
+        }
     }
 }

--- a/com.vrcfury.vrcfury/Editor/VF/Feature/Base/FeatureOrder.cs
+++ b/com.vrcfury.vrcfury/Editor/VF/Feature/Base/FeatureOrder.cs
@@ -63,6 +63,7 @@ namespace VF.Feature.Base {
         // Needs to run after toggles are in place
         // Needs to run after HapticsAnimationRewrites
         TpsScaleFix,
+        DpsTipScaleFix,
         
         FixTouchingContacts,
 

--- a/com.vrcfury.vrcfury/Editor/VF/Feature/TpsScaleFixBuilder.cs
+++ b/com.vrcfury.vrcfury/Editor/VF/Feature/TpsScaleFixBuilder.cs
@@ -1,9 +1,7 @@
 using System;
 using System.Collections.Generic;
-using System.Collections.Immutable;
 using System.Linq;
 using UnityEditor;
-using UnityEditor.Animations;
 using UnityEngine;
 using UnityEngine.UIElements;
 using VF.Builder;
@@ -15,11 +13,10 @@ using VF.Inspector;
 using VF.Model.Feature;
 using VF.Service;
 using VF.Utils;
-using VF.Utils.Controller;
 
 namespace VF.Feature {
     public class TpsScaleFixBuilder : FeatureBuilder<TpsScaleFix> {
-        [VFAutowired] private readonly ScaleFactorService scaleFactorService;
+        [VFAutowired] private readonly ScalePropertyCompensationService scaleCompensationService;
         
         [FeatureBuilderAction(FeatureOrder.TpsScaleFix)]
         public void Apply() {
@@ -37,10 +34,6 @@ namespace VF.Feature {
                     renderers.UnionWith(avatarObject.GetComponentsInSelfAndChildren<Renderer>());
                 }
             }
-            
-            var objectNumber = 0;
-            BlendTree directTree = null;
-            AnimationClip zeroClip = null;
 
             if (allRenderers) {
                 // Remove old fix attempts
@@ -54,12 +47,6 @@ namespace VF.Feature {
                 }
             }
 
-            var animatedPaths = GetFx().GetClips()
-                .SelectMany(clip => clip.GetFloatBindings())
-                .Where(IsScaleBinding)
-                .Select(b => b.path)
-                .ToImmutableHashSet();
-            
             foreach (var renderer in renderers) {
                 var pathToRenderer =
                     AnimationUtility.CalculateTransformPath(renderer.transform, avatarObject.transform);
@@ -100,89 +87,8 @@ namespace VF.Feature {
                     rootBone = skin.rootBone;
                 }
 
-                var parentPaths =
-                    rootBone.GetComponentsInSelfAndParents<Transform>()
-                        .Select(t => AnimationUtility.CalculateTransformPath(t, avatarObject.transform))
-                        .ToList();
-
-                var animatedParentPaths = parentPaths
-                    .Where(path => animatedPaths.Contains(path))
-                    .Where(path => path != "") // VRChat ignores animations of the root scale now, so we need to as well
-                    .ToList();
-
-                objectNumber++;
-                Debug.Log("Processing " + pathToRenderer);
-
-                var pathToParam = new Dictionary<string, VFAFloat>();
-                var pathNumber = 0;
-                foreach (var path in animatedParentPaths) {
-                    pathNumber++;
-                    var param = GetFx().NewFloat("shaderScale_" + objectNumber + "_" + pathNumber, def: avatarObject.transform.Find(path).localScale.z);
-                    pathToParam[path] = param;
-                    Debug.Log(path + " " + param.Name());
-                }
-                foreach (var clip in GetFx().GetClips()) {
-                    foreach (var binding in clip.GetFloatBindings()) {
-                        if (!IsScaleBinding(binding)) continue;
-                        if (!pathToParam.TryGetValue(binding.path, out var param)) continue;
-                        var newBinding = new EditorCurveBinding();
-                        newBinding.type = typeof(Animator);
-                        newBinding.path = "";
-                        newBinding.propertyName = param.Name();
-                        clip.SetFloatCurve(newBinding, clip.GetFloatCurve(binding));
-                    }
-                }
-
-                float handledScale = 1;
-                foreach (var path in animatedParentPaths) {
-                    handledScale *= avatarObject.transform.Find(path).localScale.z;
-                }
-
-                if (directTree == null) {
-                    Debug.Log("Creating direct layer");
-                    var layer = GetFx().NewLayer("shaderScale");
-                    var state = layer.NewState("Scale");
-                    directTree = GetFx().NewBlendTree("shaderScale");
-                    directTree.blendType = BlendTreeType.Direct;
-                    state.WithAnimation(directTree);
-
-                    zeroClip = GetFx().NewClip("zeroScale");
-                    var one = GetFx().One();
-                    directTree.AddDirectChild(one.Name(), zeroClip);
-                }
-
-                var scaleClip = GetFx().NewClip("tpsScale_" + objectNumber);
-                foreach (var scaledProp in scaledProps) {
-                    var propertyName = scaledProp.Key;
-                    if (scaledProp.Value is float f) {
-                        var lengthOffset = f / handledScale;
-                        scaleClip.SetCurve(pathToRenderer, renderer.GetType(), $"material.{propertyName}", ClipBuilderService.OneFrame(lengthOffset));
-                        zeroClip.SetCurve(pathToRenderer, renderer.GetType(), $"material.{propertyName}", ClipBuilderService.OneFrame(0));
-                    } else if (scaledProp.Value is Vector4 vec) {
-                        var scaleOffset = vec.z / handledScale;
-                        scaleClip.SetCurve(pathToRenderer, renderer.GetType(), $"material.{propertyName}.x", ClipBuilderService.OneFrame(scaleOffset));
-                        scaleClip.SetCurve(pathToRenderer, renderer.GetType(), $"material.{propertyName}.y", ClipBuilderService.OneFrame(scaleOffset));
-                        scaleClip.SetCurve(pathToRenderer, renderer.GetType(), $"material.{propertyName}.z", ClipBuilderService.OneFrame(scaleOffset));
-                        zeroClip.SetCurve(pathToRenderer, renderer.GetType(), $"material.{propertyName}.x", ClipBuilderService.OneFrame(0));
-                        zeroClip.SetCurve(pathToRenderer, renderer.GetType(), $"material.{propertyName}.y", ClipBuilderService.OneFrame(0));
-                        zeroClip.SetCurve(pathToRenderer, renderer.GetType(), $"material.{propertyName}.z", ClipBuilderService.OneFrame(0));
-                    }
-                }
-
-                pathToParam["nativeScale"] = scaleFactorService.Get();
-                
-                var tree = directTree;
-                foreach (var (param,index) in pathToParam.Values.Select((p,index) => (p,index))) {
-                    var isLast = index == pathToParam.Count - 1;
-                    if (isLast) {
-                        tree.AddDirectChild(param.Name(), scaleClip);
-                    } else {
-                        var subTree = GetFx().NewBlendTree("shaderScaleSub");
-                        subTree.blendType = BlendTreeType.Direct;
-                        tree.AddDirectChild(param.Name(), subTree);
-                        tree = subTree;
-                    }
-                }
+                var props = scaledProps.Select(p => (pathToRenderer, renderer.GetType(), $"material.{p.Key}", p.Value));
+                scaleCompensationService.AddScaledPorperties(rootBone, props);
             }
         }
 
@@ -216,10 +122,6 @@ namespace VF.Feature {
                 }
             }
             return scaledProps;
-        }
-
-        private static bool IsScaleBinding(EditorCurveBinding binding) {
-            return binding.type == typeof(Transform) && binding.propertyName == "m_LocalScale.z";
         }
 
         public override string GetEditorTitle() {

--- a/com.vrcfury.vrcfury/Editor/VF/Service/ScalePropertyCompensationService.cs
+++ b/com.vrcfury.vrcfury/Editor/VF/Service/ScalePropertyCompensationService.cs
@@ -1,0 +1,120 @@
+using System;
+using System.Collections.Generic;
+using System.Collections.Immutable;
+using System.Linq;
+using UnityEditor;
+using UnityEditor.Animations;
+using UnityEngine;
+using VF.Builder;
+using VF.Injector;
+using VF.Utils;
+using VF.Utils.Controller;
+
+namespace VF.Service {
+    /**
+     * Handles creating the DirectTree for properties that need correction when scaling the avatar
+     */
+    [VFService]
+    public class ScalePropertyCompensationService {
+        [VFAutowired] private readonly AvatarManager manager;
+        [VFAutowired] private readonly ScaleFactorService scaleFactorService;
+
+        private int objectNumber = 0;
+        private BlendTree directTree = null;
+        private AnimationClip zeroClip = null;
+
+        public void AddScaledPorperties(VFGameObject scaleReference, IEnumerable<(string ObjectPath, Type ComponentType, string PropertyName, object InitialValue)> properties) {
+            var animatedPaths = manager.GetFx().GetClips()
+                .SelectMany(clip => clip.GetFloatBindings())
+                .Where(IsScaleBinding)
+                .Select(b => b.path)
+                .ToImmutableHashSet();
+
+            var parentPaths = scaleReference.GetComponentsInSelfAndParents<Transform>()
+                .Select(t => AnimationUtility.CalculateTransformPath(t, manager.AvatarObject.transform))
+                .ToList();
+
+            var animatedParentPaths = parentPaths
+                .Where(path => animatedPaths.Contains(path))
+                .Where(path => path != "") // VRChat ignores animations of the root scale now, so we need to as well
+                .ToList();
+
+            var pathToParam = new Dictionary<string, VFAFloat>();
+            var pathNumber = 0;
+            foreach (var path in animatedParentPaths) {
+                pathNumber++;
+                var param = manager.GetFx().NewFloat("shaderScale_" + objectNumber + "_" + pathNumber, def: manager.AvatarObject.transform.Find(path).localScale.z);
+                pathToParam[path] = param;
+                Debug.Log(path + " " + param.Name());
+            }
+            foreach (var clip in manager.GetFx().GetClips()) {
+                foreach (var binding in clip.GetFloatBindings()) {
+                    if (!IsScaleBinding(binding)) continue;
+                    if (!pathToParam.TryGetValue(binding.path, out var param)) continue;
+                    var newBinding = new EditorCurveBinding();
+                    newBinding.type = typeof(Animator);
+                    newBinding.path = "";
+                    newBinding.propertyName = param.Name();
+                    clip.SetFloatCurve(newBinding, clip.GetFloatCurve(binding));
+                }
+            }
+
+            float handledScale = 1;
+            foreach (var path in animatedParentPaths) {
+                handledScale *= manager.AvatarObject.transform.Find(path).localScale.z;
+            }
+
+            if (directTree == null) {
+                Debug.Log("Creating direct layer");
+                var layer = manager.GetFx().NewLayer("shaderScale");
+                var state = layer.NewState("Scale");
+                directTree = manager.GetFx().NewBlendTree("shaderScale");
+                directTree.blendType = BlendTreeType.Direct;
+                state.WithAnimation(directTree);
+
+                zeroClip = manager.GetFx().NewClip("zeroScale");
+                var one = manager.GetFx().One();
+                directTree.AddDirectChild(one.Name(), zeroClip);
+            }
+
+            var scaleClip = manager.GetFx().NewClip("tpsScale_" + objectNumber);
+            foreach (var prop in properties) {
+                objectNumber++;
+                Debug.Log("Processing " + prop.ObjectPath);
+
+                if (prop.InitialValue is float f) {
+                    var lengthOffset = f / handledScale;
+                    scaleClip.SetCurve(prop.ObjectPath, prop.ComponentType, prop.PropertyName, ClipBuilderService.OneFrame(lengthOffset));
+                    zeroClip.SetCurve(prop.ObjectPath, prop.ComponentType, prop.PropertyName, ClipBuilderService.OneFrame(0));
+                } else if (prop.InitialValue is Vector4 vec) {
+                    var scaleOffset = vec.z / handledScale;
+                    scaleClip.SetCurve(prop.ObjectPath, prop.ComponentType, prop.PropertyName, ClipBuilderService.OneFrame(scaleOffset));
+                    scaleClip.SetCurve(prop.ObjectPath, prop.ComponentType, prop.PropertyName, ClipBuilderService.OneFrame(scaleOffset));
+                    scaleClip.SetCurve(prop.ObjectPath, prop.ComponentType, prop.PropertyName, ClipBuilderService.OneFrame(scaleOffset));
+                    zeroClip.SetCurve(prop.ObjectPath, prop.ComponentType, prop.PropertyName, ClipBuilderService.OneFrame(0));
+                    zeroClip.SetCurve(prop.ObjectPath, prop.ComponentType, prop.PropertyName, ClipBuilderService.OneFrame(0));
+                    zeroClip.SetCurve(prop.ObjectPath, prop.ComponentType, prop.PropertyName, ClipBuilderService.OneFrame(0));
+                }
+            }
+
+            pathToParam["nativeScale"] = scaleFactorService.Get();
+
+            var tree = directTree;
+            foreach (var (param, index) in pathToParam.Values.Select((p, index) => (p, index))) {
+                var isLast = index == pathToParam.Count - 1;
+                if (isLast) {
+                    tree.AddDirectChild(param.Name(), scaleClip);
+                } else {
+                    var subTree = manager.GetFx().NewBlendTree("shaderScaleSub");
+                    subTree.blendType = BlendTreeType.Direct;
+                    tree.AddDirectChild(param.Name(), subTree);
+                    tree = subTree;
+                }
+            }
+        }
+
+        private static bool IsScaleBinding(EditorCurveBinding binding) {
+            return binding.type == typeof(Transform) && binding.propertyName == "m_LocalScale.z";
+        }
+    }
+}

--- a/com.vrcfury.vrcfury/Editor/VF/Service/ScalePropertyCompensationService.cs.meta
+++ b/com.vrcfury.vrcfury/Editor/VF/Service/ScalePropertyCompensationService.cs.meta
@@ -1,0 +1,11 @@
+fileFormatVersion: 2
+guid: f860e5e13a768044ab74f0d6d4c31855
+MonoImporter:
+  externalObjects: {}
+  serializedVersion: 2
+  defaultReferences: []
+  executionOrder: 0
+  icon: {instanceID: 0}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 


### PR DESCRIPTION
Fixes #93 

The tip light intensity is used to transmit the length of penetrator to DPS deformation shaders
This pr reuses the logic in TpsScaleFix to apply scaling to the DPS tip light intensity

The scaling logic was moved into ScaleFactorService to allow code reuse.
I've used an IEnumerable tuple to pass a list of properties to scale, however, I can alter that (such as using a structure) if preferred.

```
The changes made in this contribution are free and unencumbered software
released into the public domain.

Anyone is free to copy, modify, publish, use, compile, sell, or
distribute this software, either in source code form or as a compiled
binary, for any purpose, commercial or non-commercial, and by any
means.

In jurisdictions that recognize copyright laws, the author or authors
of this software dedicate any and all copyright interest in the
software to the public domain. We make this dedication for the benefit
of the public at large and to the detriment of our heirs and
successors. We intend this dedication to be an overt act of
relinquishment in perpetuity of all present and future rights to this
software under copyright law.

THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND,
EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF
MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT.
IN NO EVENT SHALL THE AUTHORS BE LIABLE FOR ANY CLAIM, DAMAGES OR
OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE,
ARISING FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR
OTHER DEALINGS IN THE SOFTWARE.

For more information, please refer to <https://unlicense.org>
```