### PR TITLE
Gesture driver: make smoothing configurable

### DIFF
--- a/com.vrcfury.vrcfury/Editor/VF/Feature/GestureDriverBuilder.cs
+++ b/com.vrcfury.vrcfury/Editor/VF/Feature/GestureDriverBuilder.cs
@@ -143,7 +143,7 @@ namespace VF.Feature {
                     (input, whenEnabled),
                     (null, null)
                 );
-            return smoothing.Smooth($"{input.Name()}Smoothed", maintained, 0.2f);
+            return smoothing.Smooth($"{input.Name()}Smoothed", maintained, model.smoothingDuration);
         }
 
         public override string GetEditorTitle() {
@@ -151,8 +151,23 @@ namespace VF.Feature {
         }
 
         public override VisualElement CreateEditor(SerializedProperty prop) {
-            return VRCFuryEditorUtils.List(prop.FindPropertyRelative("gestures"),
-                (i,el) => RenderGestureEditor(el));
+            var content = new VisualElement();
+            SerializedProperty gestures = prop.FindPropertyRelative("gestures");
+            content.Add(VRCFuryEditorUtils.List(gestures, (i,el) => RenderGestureEditor(el)));
+            foreach (SerializedProperty gesture in gestures) 
+            {
+                if (gesture.FindPropertyRelative("enableWeight").boolValue) 
+                {
+                    var smoothingDuration = prop.FindPropertyRelative("smoothingDuration");
+                    var section = VRCFuryEditorUtils.Section("Parameter smoothing");
+                    section.Add(VRCFuryEditorUtils.WrappedLabel("Gesture weight parameter smoothing in seconds, set to 0 to disable smoothing."));
+                    section.Add(new VisualElement { style = { paddingTop = 10 } });
+                    section.Add(VRCFuryEditorUtils.Prop(smoothingDuration, "Duration"));
+                    content.Add(section);
+                    break;    
+                }
+            }
+            return content;
         }
 
         private VisualElement RenderGestureEditor(SerializedProperty gesture) {

--- a/com.vrcfury.vrcfury/Runtime/VF/Model/Feature.cs
+++ b/com.vrcfury.vrcfury/Runtime/VF/Model/Feature.cs
@@ -540,6 +540,8 @@ namespace VF.Model.Feature {
     [Serializable]
     public class GestureDriver : NewFeatureModel {
         public List<Gesture> gestures = new List<Gesture>();
+
+        public float smoothingDuration = 0.2f;
         
         [Serializable]
         public class Gesture {


### PR DESCRIPTION
This has changed slightly and for me the gesture weights are now a bit too smoothed. Instead of forcing everyone to use the same smoothing, this change makes it configurable.

The hardest part was to figure out the UI for it, it currently looks like this, but open for suggestions:

![image](https://github.com/VRCFury/VRCFury/assets/140460527/baccbaa1-1f7f-463d-bf6c-7a935c148990)

```
The changes made in this contribution are free and unencumbered software
released into the public domain.

Anyone is free to copy, modify, publish, use, compile, sell, or
distribute this software, either in source code form or as a compiled
binary, for any purpose, commercial or non-commercial, and by any
means.

In jurisdictions that recognize copyright laws, the author or authors
of this software dedicate any and all copyright interest in the
software to the public domain. We make this dedication for the benefit
of the public at large and to the detriment of our heirs and
successors. We intend this dedication to be an overt act of
relinquishment in perpetuity of all present and future rights to this
software under copyright law.

THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND,
EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF
MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT.
IN NO EVENT SHALL THE AUTHORS BE LIABLE FOR ANY CLAIM, DAMAGES OR
OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE,
ARISING FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR
OTHER DEALINGS IN THE SOFTWARE.

For more information, please refer to <https://unlicense.org>
```