### PR TITLE
Full controller smoothed parameters support.

### DIFF
--- a/com.vrcfury.vrcfury/Editor/VF/Builder/Manager/ControllerManager.cs
+++ b/com.vrcfury.vrcfury/Editor/VF/Builder/Manager/ControllerManager.cs
@@ -27,6 +27,7 @@ namespace VF.Builder {
         private readonly Dictionary<AnimatorStateMachine, string> layerOwners =
             new Dictionary<AnimatorStateMachine, string>();
         private readonly List<AvatarMask> unionedBaseMasks = new List<AvatarMask>();
+        private readonly List<SmoothParam> smoothedParams = new List<SmoothParam>();
     
         public ControllerManager(
             VFController ctrl,
@@ -220,6 +221,10 @@ namespace VF.Builder {
             return ctrl.NewFloat(name, def);
         }
 
+        public void Smooth(string name, float smoothingSeconds, bool useAcceleration = true) {
+            smoothedParams.Add(new SmoothParam{name = name, smoothingDuration = smoothingSeconds, useAcceleration = useAcceleration});
+        }
+
         public VFABool True() {
             return NewBool("VF_True", def: true, usePrefix: false);
         }
@@ -261,6 +266,10 @@ namespace VF.Builder {
             return unionedBaseMasks;
         }
 
+        public List<SmoothParam> GetSmoothedParams() {
+            return smoothedParams;
+        }
+
         public string GetLayerOwner(AnimatorStateMachine stateMachine) {
             if (!layerOwners.TryGetValue(stateMachine, out var layerOwner)) {
                 return null;
@@ -280,6 +289,12 @@ namespace VF.Builder {
 
         public IImmutableSet<AnimationClip> GetClips() {
             return new AnimatorIterator.Clips().From(GetRaw());
+        }
+
+        public class SmoothParam {
+            public string name;
+            public float smoothingDuration;
+            public bool useAcceleration;
         }
     }
 }

--- a/com.vrcfury.vrcfury/Editor/VF/Builder/VRCFuryBuilder.cs
+++ b/com.vrcfury.vrcfury/Editor/VF/Builder/VRCFuryBuilder.cs
@@ -137,6 +137,7 @@ public class VRCFuryBuilder {
         AddBuilder(typeof(FixMasksBuilder));
         AddBuilder(typeof(CleanupEmptyLayersBuilder));
         AddBuilder(typeof(ResetAnimatorBuilder));
+        AddBuilder(typeof(ParameterSmoothingBuilder));
         AddBuilder(typeof(FixBadVrcParameterNamesBuilder));
         AddBuilder(typeof(FinalizeMenuBuilder));
         AddBuilder(typeof(FinalizeParamsBuilder));

--- a/com.vrcfury.vrcfury/Editor/VF/Feature/Base/FeatureOrder.cs
+++ b/com.vrcfury.vrcfury/Editor/VF/Feature/Base/FeatureOrder.cs
@@ -75,6 +75,7 @@ namespace VF.Feature.Base {
 
         // Finalize Controllers
         BlendShapeLinkFixAnimations, // Needs to run after most things are done messing with animations, since it'll make copies of the blendshape curves
+        ParameterSmoothing, // Needs to run before DirectTreeOptimizer so smoothing gets optmized by it
         DirectTreeOptimizer, // Needs to run after animations are done, but before RecordDefaults
         RecordAllDefaults,
         BlendshapeOptimizer, // Needs to run after RecordDefaults

--- a/com.vrcfury.vrcfury/Editor/VF/Feature/FullControllerBuilder.cs
+++ b/com.vrcfury.vrcfury/Editor/VF/Feature/FullControllerBuilder.cs
@@ -15,6 +15,7 @@ using VF.Inspector;
 using VF.Model;
 using VF.Model.Feature;
 using VF.Model.StateAction;
+using VF.Service;
 using VF.Utils;
 using VF.Utils.Controller;
 using VRC.SDK3.Avatars.Components;
@@ -27,6 +28,7 @@ namespace VF.Feature {
 
     public class FullControllerBuilder : FeatureBuilder<FullController> {
         [VFAutowired] private readonly AnimatorLayerControlOffsetBuilder animatorLayerControlManager;
+        [VFAutowired] private readonly ParamSmoothingService smoothing;
 
         [FeatureBuilderAction(FeatureOrder.FullController)]
         public void Apply() {
@@ -259,6 +261,27 @@ namespace VF.Feature {
             // (we do this after rewriting paths to ensure animator bindings all hit "")
             ((AnimatorController)from).RewriteParameters(RewriteParamName);
 
+            var smoothedParams = model.smoothedPrms.ToDictionary(
+                x => x.name == "*" ? x.name : RewriteParamName(x.name), 
+                x => x);
+            var fromParams = from.parameters.ToDictionary(x => x.name, x => x);
+            from.RewriteParameters(param => 
+            {
+                if (string.IsNullOrWhiteSpace(param)) return param;
+                if (fromParams[param].type != AnimatorControllerParameterType.Float) return param;
+                FullController.SmoothParamEntry smoothParam;
+                if (smoothedParams.TryGetValue(param, out smoothParam) || 
+                        smoothedParams.TryGetValue("*", out smoothParam))
+                {
+                    var result = smoothing.Smooth(
+                        param, 
+                        new VFAFloat(fromParams[param]), 
+                        smoothParam.smoothingDuration);
+                    return result.Name();
+                }
+                return param;
+            }, includeWrites: false);
+
             // Merge base mask
             if (type == VRCAvatarDescriptor.AnimLayerType.Gesture && from.layers.Length > 0) {
                 var mask = from.layers[0].avatarMask;
@@ -343,6 +366,52 @@ namespace VF.Feature {
             content.Add(VRCFuryEditorUtils.List(prop.FindPropertyRelative("prms"),
                 (i, el) => VRCFuryEditorUtils.Prop(el.FindPropertyRelative("parameters"))));
             
+            content.Add(VRCFuryEditorUtils.WrappedLabel("Smoothed Parameters:"));
+            content.Add(VRCFuryEditorUtils.List(prop.FindPropertyRelative("smoothedPrms"),
+                (i, el) =>
+                {
+                    var wrapper = new VisualElement();
+                    wrapper.style.flexDirection = FlexDirection.Row;
+                    SerializedProperty nameProp = el.FindPropertyRelative("name");
+                    var a = VRCFuryEditorUtils.Prop(nameProp);
+                    a.style.flexBasis = 0;
+                    a.style.flexGrow = 2;
+                    wrapper.Add(a);
+                    var b = VRCFuryEditorUtils.Prop(el.FindPropertyRelative("smoothingDuration"));
+                    b.style.flexBasis = 0;
+                    b.style.flexGrow = 1;
+                    wrapper.Add(b);
+
+                    System.Action selectButtonPress = () =>
+                    {
+                        var prms = prop.FindPropertyRelative("prms");
+                        var menu = new GenericMenu();
+                        foreach (SerializedProperty paramEntry in prms)
+                        {
+                            var guid = paramEntry.FindPropertyRelative("parameters.id");
+                            var value = VrcfObjectId.IdToObject<VRCExpressionParameters>(guid.stringValue);
+
+                            foreach (var param in value.parameters)
+                            {
+                                if (param.valueType == VRCExpressionParameters.ValueType.Float)
+                                {
+                                    menu.AddItem(new GUIContent(param.name.Replace("/", "\u2215")), false, () =>
+                                    {
+                                        nameProp.stringValue = param.name;
+                                        nameProp.serializedObject.ApplyModifiedProperties();
+                                    });
+                                }
+                            }
+                        }
+                        menu.ShowAsContext();
+                    };
+                    var selectButton = new Button(selectButtonPress) { text = "Select" };
+                    wrapper.Add(selectButton);
+
+                    return wrapper;
+                }));
+
+
             content.Add(VRCFuryEditorUtils.WrappedLabel("Global Parameters:"));
             content.Add(VRCFuryEditorUtils.WrappedLabel(
                 "Parameters in this list will have their name kept as is, allowing you to interact with " +

--- a/com.vrcfury.vrcfury/Editor/VF/Feature/FullControllerBuilder.cs
+++ b/com.vrcfury.vrcfury/Editor/VF/Feature/FullControllerBuilder.cs
@@ -258,9 +258,7 @@ namespace VF.Feature {
             ));
 
             // Parameter smoothing
-            var paramsBeforeRewrite = from.parameters.ToDictionary(x => x.name, x => x);
-            var smoothedParams = model.smoothedPrms.Where(param => paramsBeforeRewrite.ContainsKey(param.name));
-            foreach (var smoothedParam in smoothedParams) {
+            foreach (var smoothedParam in model.smoothedPrms) {
                 toMain.Smooth(RewriteParamName(smoothedParam.name),
                     smoothedParam.smoothingDuration);
             }

--- a/com.vrcfury.vrcfury/Editor/VF/Feature/FullControllerBuilder.cs
+++ b/com.vrcfury.vrcfury/Editor/VF/Feature/FullControllerBuilder.cs
@@ -266,7 +266,7 @@ namespace VF.Feature {
             from.RewriteParameters(param => 
             {
                 if (string.IsNullOrWhiteSpace(param)) return param;
-                if (fromParams[param].type != AnimatorControllerParameterType.Float) return param;
+                if (!fromParams.ContainsKey(param) || fromParams[param].type != AnimatorControllerParameterType.Float) return param;
                 if (smoothedParams.TryGetValue(param, out var smoothParam))
                 {
                     var result = smoothing.Smooth(

--- a/com.vrcfury.vrcfury/Editor/VF/Feature/ParameterSmoothingBuilder.cs
+++ b/com.vrcfury.vrcfury/Editor/VF/Feature/ParameterSmoothingBuilder.cs
@@ -1,0 +1,52 @@
+using System.Linq;
+using VF.Feature.Base;
+using VF.Injector;
+using VF.Service;
+using VF.Utils;
+using VF.Builder;
+using VRC.SDK3.Avatars.Components;
+using System.Collections.Concurrent;
+using UnityEditor.Animations;
+using VF.Utils.Controller;
+
+namespace VF.Feature
+{
+    public class ParameterSmoothingBuilder : FeatureBuilder
+    {
+
+        [VFAutowired] private readonly ParamSmoothingService smoothing;
+
+        [FeatureBuilderAction(FeatureOrder.ParameterSmoothing)]
+        public void Apply()
+        {
+            var avatar = avatarObject.GetComponent<VRCAvatarDescriptor>();
+
+            foreach (var c in manager.GetAllUsedControllers()) {
+                ReplaceUsagesOfSmoothedParameters(c);
+            }
+        }
+
+         private void ReplaceUsagesOfSmoothedParameters(ControllerManager c)
+        {
+            var smoothedParams = c.GetSmoothedParams().ToDictionary(v => v.name, v => v);
+            if (smoothedParams.Count == 0) {
+                return;
+            }
+            var raw = c.GetRaw();
+            var paramsMap = raw.parameters.ToDictionary(x => x.name, x => x);
+            var smoothedParamCache = new ConcurrentDictionary<string, string>();
+            ((AnimatorController)raw).RewriteParameters(param => {
+                if (smoothedParams.TryGetValue(param, out var smoothedParam)) {
+                    return smoothedParamCache.GetOrAdd(param, _ => 
+                        smoothing.Smooth(c, 
+                            param, 
+                            new VFAFloat(paramsMap[param]), 
+                            smoothedParam.smoothingDuration, 
+                            smoothedParam.useAcceleration)
+                        .Name());
+                }
+                return param;
+            }, includeWrites: false);
+        }
+    }
+}

--- a/com.vrcfury.vrcfury/Editor/VF/Feature/ParameterSmoothingBuilder.cs
+++ b/com.vrcfury.vrcfury/Editor/VF/Feature/ParameterSmoothingBuilder.cs
@@ -1,13 +1,13 @@
+using System.Collections.Concurrent;
 using System.Linq;
+using UnityEditor.Animations;
+using VF.Builder;
 using VF.Feature.Base;
 using VF.Injector;
 using VF.Service;
 using VF.Utils;
-using VF.Builder;
-using VRC.SDK3.Avatars.Components;
-using System.Collections.Concurrent;
-using UnityEditor.Animations;
 using VF.Utils.Controller;
+using VRC.SDK3.Avatars.Components;
 
 namespace VF.Feature
 {
@@ -26,7 +26,7 @@ namespace VF.Feature
             }
         }
 
-         private void ReplaceUsagesOfSmoothedParameters(ControllerManager c)
+        private void ReplaceUsagesOfSmoothedParameters(ControllerManager c)
         {
             var smoothedParams = c.GetSmoothedParams().ToDictionary(v => v.name, v => v);
             if (smoothedParams.Count == 0) {

--- a/com.vrcfury.vrcfury/Editor/VF/Feature/ParameterSmoothingBuilder.cs.meta
+++ b/com.vrcfury.vrcfury/Editor/VF/Feature/ParameterSmoothingBuilder.cs.meta
@@ -1,0 +1,11 @@
+fileFormatVersion: 2
+guid: 6ea8de35ad3461e4cb69aa90f587c62c
+MonoImporter:
+  externalObjects: {}
+  serializedVersion: 2
+  defaultReferences: []
+  executionOrder: 0
+  icon: {instanceID: 0}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/com.vrcfury.vrcfury/Editor/VF/Service/ParamSmoothingService.cs
+++ b/com.vrcfury.vrcfury/Editor/VF/Service/ParamSmoothingService.cs
@@ -1,37 +1,35 @@
-using System;
-using System.Collections.Generic;
 using System.Linq;
 using UnityEditor;
 using UnityEditor.Animations;
 using UnityEngine;
 using VF.Builder;
 using VF.Component;
-using VF.Feature.Base;
 using VF.Injector;
 using VF.Utils;
 using VF.Utils.Controller;
 
-namespace VF.Service {
+namespace VF.Service
+{
 
     [VFService]
     public class ParamSmoothingService {
         [VFAutowired] private readonly AvatarManager avatarManager;
-
-        public VFAFloat Smooth(string name, VFAFloat target, float smoothingSeconds, bool useAcceleration = true) {
-            return Smooth(avatarManager.GetFx(), name, target, smoothingSeconds, useAcceleration);
-        }
         
         public VFAFloat Smooth(ControllerManager controller, string name, VFAFloat target, float smoothingSeconds, bool useAcceleration = true) {
             if (smoothingSeconds <= 0) return target;
             if (smoothingSeconds > 10) smoothingSeconds = 10;
             var fractionPerFrame = GetFractionPerFrame(smoothingSeconds, useAcceleration);
 
-            var fx = avatarManager.GetFx();
-            var speedParam = fx.NewFloat($"{name}/FractionPerFrame", def: fractionPerFrame);
+            var speedParam = controller.NewFloat($"{name}/FractionPerFrame", def: fractionPerFrame);
 
-            var output = Smooth_($"{name}/Pass1", target, speedParam);
-            if (useAcceleration) output = Smooth_($"{name}/Pass2", output, speedParam);
+            var output = Smooth_(controller, $"{name}/Pass1", target, speedParam);
+            if (useAcceleration) output = Smooth_(controller, "{name}/Pass2", output, speedParam);
+            
             return output;
+        }
+        
+        public VFAFloat Smooth(string name, VFAFloat target, float smoothingSeconds, bool useAcceleration = true) {
+            return Smooth(avatarManager.GetFx(), name, target, smoothingSeconds, useAcceleration);
         }
 
         private float GetFractionPerFrame(float seconds, bool useAcceleration) {
@@ -51,19 +49,17 @@ namespace VF.Service {
             return currentSpeed;
         }
 
-        private VFAFloat Smooth_(string name, VFAFloat target, VFAFloat speedParam) {
-            var fx = avatarManager.GetFx();
-
-            var output = fx.NewFloat(name, def: target.GetDefault());
+        private VFAFloat Smooth_(ControllerManager controller, string name, VFAFloat target, VFAFloat speedParam) {
+            var output = controller.NewFloat(name, def: target.GetDefault());
             
             // These clips drive the output param to certain values
-            var minClip = fx.NewClip($"{output.Name()}-1");
+            var minClip = controller.NewClip($"{output.Name()}-1");
             minClip.SetCurve("", typeof(Animator), output.Name(), AnimationCurve.Constant(0, 0, -1f));
-            var maxClip = fx.NewClip($"{output.Name()}1");
+            var maxClip = controller.NewClip($"{output.Name()}1");
             maxClip.SetCurve("", typeof(Animator), output.Name(), AnimationCurve.Constant(0, 0, 1f));
 
             // Maintain tree - keeps the current value
-            var maintainTree = fx.NewBlendTree($"{output.Name()}_do_not_change");
+            var maintainTree = controller.NewBlendTree($"{output.Name()}_do_not_change");
             maintainTree.blendType = BlendTreeType.Simple1D;
             maintainTree.useAutomaticThresholds = false;
             maintainTree.blendParameter = output.Name();
@@ -71,7 +67,7 @@ namespace VF.Service {
             maintainTree.AddChild(maxClip, 1);
 
             // Target tree - uses the target (input) value
-            var targetTree = fx.NewBlendTree($"{output.Name()}_lock_to_{target.Name()}");
+            var targetTree = controller.NewBlendTree($"{output.Name()}_lock_to_{target.Name()}");
             targetTree.blendType = BlendTreeType.Simple1D;
             targetTree.useAutomaticThresholds = false;
             targetTree.blendParameter = target.Name();
@@ -80,14 +76,14 @@ namespace VF.Service {
 
             //The following two trees merge the update and the maintain tree together. The smoothParam controls 
             //how much from either tree should be applied during each tick
-            var smoothTree = fx.NewBlendTree($"{output.Name()}_smooth_to_{target.Name()}");
+            var smoothTree = controller.NewBlendTree($"{output.Name()}_smooth_to_{target.Name()}");
             smoothTree.blendType = BlendTreeType.Simple1D;
             smoothTree.useAutomaticThresholds = false;
             smoothTree.blendParameter = speedParam.Name();
             smoothTree.AddChild(maintainTree, 0);
             smoothTree.AddChild(targetTree, 1);
 
-            var layer = fx.NewLayer("Smoothing " + name);
+            var layer = controller.NewLayer("Smoothing " + name);
             layer.NewState("Smooth").WithAnimation(smoothTree);
             return output;
         }

--- a/com.vrcfury.vrcfury/Editor/VF/Service/ParamSmoothingService.cs
+++ b/com.vrcfury.vrcfury/Editor/VF/Service/ParamSmoothingService.cs
@@ -16,8 +16,12 @@ namespace VF.Service {
     [VFService]
     public class ParamSmoothingService {
         [VFAutowired] private readonly AvatarManager avatarManager;
-        
+
         public VFAFloat Smooth(string name, VFAFloat target, float smoothingSeconds, bool useAcceleration = true) {
+            return Smooth(avatarManager.GetFx(), name, target, smoothingSeconds, useAcceleration);
+        }
+        
+        public VFAFloat Smooth(ControllerManager controller, string name, VFAFloat target, float smoothingSeconds, bool useAcceleration = true) {
             if (smoothingSeconds <= 0) return target;
             if (smoothingSeconds > 10) smoothingSeconds = 10;
             var fractionPerFrame = GetFractionPerFrame(smoothingSeconds, useAcceleration);

--- a/com.vrcfury.vrcfury/Runtime/VF/Model/Feature.cs
+++ b/com.vrcfury.vrcfury/Runtime/VF/Model/Feature.cs
@@ -107,6 +107,7 @@ namespace VF.Model.Feature {
         public List<ControllerEntry> controllers = new List<ControllerEntry>();
         public List<MenuEntry> menus = new List<MenuEntry>();
         public List<ParamsEntry> prms = new List<ParamsEntry>();
+        public List<SmoothParamEntry> smoothedPrms = new List<SmoothParamEntry>();
         public List<string> globalParams = new List<string>();
         public bool allNonsyncedAreGlobal = false;
         public bool ignoreSaved;
@@ -149,6 +150,13 @@ namespace VF.Model.Feature {
             public string from;
             public string to;
             public bool delete = false;
+            public bool ResetMePlease2;
+        }
+
+        [Serializable]
+        public class SmoothParamEntry {
+            public string name;
+            public float smoothingDuration = 0.2f;
             public bool ResetMePlease2;
         }
 


### PR DESCRIPTION
This adds support for smoothing parameters in the full controller feature.

A list of smoothed parameters can be provided, each with individual smoothing duration values. Alternatively you can specify `*`, which will enable smoothing for all float parameters.

I was struggling with the UI again but hopefully it's good enough. I was using the BlendShape field as inspiration for this.

![image](https://github.com/VRCFury/VRCFury/assets/140460527/d08b79ea-de8a-4803-8991-3fd4a57a2ca6)

Also, I didn't realize how janky it is to get the parameters from the serialized object. There's probably a better way to do it, please let me know!

```
The changes made in this contribution are free and unencumbered software
released into the public domain.

Anyone is free to copy, modify, publish, use, compile, sell, or
distribute this software, either in source code form or as a compiled
binary, for any purpose, commercial or non-commercial, and by any
means.

In jurisdictions that recognize copyright laws, the author or authors
of this software dedicate any and all copyright interest in the
software to the public domain. We make this dedication for the benefit
of the public at large and to the detriment of our heirs and
successors. We intend this dedication to be an overt act of
relinquishment in perpetuity of all present and future rights to this
software under copyright law.

THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND,
EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF
MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT.
IN NO EVENT SHALL THE AUTHORS BE LIABLE FOR ANY CLAIM, DAMAGES OR
OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE,
ARISING FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR
OTHER DEALINGS IN THE SOFTWARE.

For more information, please refer to <https://unlicense.org>
```