### PR TITLE
SPS: Allow configuring whether ring sockets are bidirectional

### DIFF
--- a/com.vrcfury.vrcfury/CONTRIBUTING.md
+++ b/com.vrcfury.vrcfury/CONTRIBUTING.md
@@ -88,6 +88,7 @@ For more information, please refer to <https://unlicense.org>
   * Added scaling of legacy DPS tip light intensity
   * Add option for using local space for socket units
   * Add option for exact matching in BlendShapeLink
+  * Allow configuring whether ring sockets are bidirectional
 * Toys0125
   * Added Poiyomi UV Tile action type
 * wholesomevr

--- a/com.vrcfury.vrcfury/Editor/VF/Builder/Haptics/HapticUtils.cs
+++ b/com.vrcfury.vrcfury/Editor/VF/Builder/Haptics/HapticUtils.cs
@@ -27,6 +27,7 @@ namespace VF.Builder.Haptics {
         public static string TagSpsSocketFront = "SPSLL_Socket_Front";
         public static string TagSpsSocketIsRing = "SPSLL_Socket_Ring";
         public static string TagSpsSocketIsHole = "SPSLL_Socket_Hole";
+        public static string TagSpsSocketIsBidirectional = "SPSLL_Socket_Bidirectional";
 
         public static readonly string[] SelfContacts = {
             "Hand",

--- a/com.vrcfury.vrcfury/Editor/VF/Builder/Haptics/LegacyHapticsUpgrader.cs
+++ b/com.vrcfury.vrcfury/Editor/VF/Builder/Haptics/LegacyHapticsUpgrader.cs
@@ -242,7 +242,8 @@ namespace VF.Builder.Haptics {
                 var ringMarker = t.Find("OGB_Marker_Ring");
                 if (ringMarker) {
                     var o = AddSocket(t);
-                    if (o) o.addLight = VRCFuryHapticSocketEditor.ShouldProbablyBeReversible(o) ? VRCFuryHapticSocket.AddLight.RingBidirectional : VRCFuryHapticSocket.AddLight.Ring;
+                    // Upgrade rings to bidirectional
+                    if (o) o.addLight = VRCFuryHapticSocket.AddLight.RingBidirectional;
                     objectsToDelete.Add(ringMarker);
                 }
             }
@@ -258,7 +259,8 @@ namespace VF.Builder.Haptics {
                                 var position = info.Item2;
                                 var rotation = info.Item3;
                                 if (type == VRCFuryHapticSocket.AddLight.Ring)
-                                    socket.addLight = VRCFuryHapticSocketEditor.ShouldProbablyBeReversible(socket) ? VRCFuryHapticSocket.AddLight.RingBidirectional : VRCFuryHapticSocket.AddLight.Ring;
+                                    // Upgrade rings to bidirectional
+                                    socket.addLight = VRCFuryHapticSocket.AddLight.RingBidirectional;
                                 else
                                     socket.addLight = type;
                                 socket.position = position;

--- a/com.vrcfury.vrcfury/Editor/VF/Builder/Haptics/LegacyHapticsUpgrader.cs
+++ b/com.vrcfury.vrcfury/Editor/VF/Builder/Haptics/LegacyHapticsUpgrader.cs
@@ -242,7 +242,7 @@ namespace VF.Builder.Haptics {
                 var ringMarker = t.Find("OGB_Marker_Ring");
                 if (ringMarker) {
                     var o = AddSocket(t);
-                    if (o) o.addLight = VRCFuryHapticSocket.AddLight.Ring;
+                    if (o) o.addLight = VRCFuryHapticSocketEditor.ShouldProbablyBeReversible(o) ? VRCFuryHapticSocket.AddLight.RingBidirectional : VRCFuryHapticSocket.AddLight.Ring;
                     objectsToDelete.Add(ringMarker);
                 }
             }
@@ -257,7 +257,10 @@ namespace VF.Builder.Haptics {
                                 var type = info.Item1;
                                 var position = info.Item2;
                                 var rotation = info.Item3;
-                                socket.addLight = type;
+                                if (type == VRCFuryHapticSocket.AddLight.Ring)
+                                    socket.addLight = VRCFuryHapticSocketEditor.ShouldProbablyBeReversible(socket) ? VRCFuryHapticSocket.AddLight.RingBidirectional : VRCFuryHapticSocket.AddLight.Ring;
+                                else
+                                    socket.addLight = type;
                                 socket.position = position;
                                 socket.rotation = rotation.eulerAngles;
                             }

--- a/com.vrcfury.vrcfury/Editor/VF/Feature/BakeHapticPlugsBuilder.cs
+++ b/com.vrcfury.vrcfury/Editor/VF/Feature/BakeHapticPlugsBuilder.cs
@@ -163,12 +163,16 @@ namespace VF.Feature {
                                 var isRing = hapticContacts.AddReceiver(triRoot, Vector3.zero, $"sps_tri_{i}_lightMarker",
                                     "IsRing", 3f, new[] { HapticUtils.TagSpsSocketIsRing },
                                     party, useHipAvoidance: plug.useHipAvoidance);
-                            
+                                var isBidirectional = hapticContacts.AddReceiver(triRoot, Vector3.zero, $"sps_tri_{i}_lightMarker",
+                                    "IsBidirectional", 3f, new[] { HapticUtils.TagSpsSocketIsBidirectional },
+                                    party, useHipAvoidance: plug.useHipAvoidance);
+
                                 foreach (var r in renderers) {
                                     _triangulationService.SendToShader(tri, $"_SPS_Tri_{prefix}_Root", r.renderer);
                                     _triangulationService.SendToShader(triFront, $"_SPS_Tri_{prefix}_Front", r.renderer);
                                     _triangulationService.SendParamToShader(isHole, $"_SPS_Tri_{prefix}_IsHole", r.renderer);
                                     _triangulationService.SendParamToShader(isRing, $"_SPS_Tri_{prefix}_IsRing", r.renderer);
+                                    _triangulationService.SendParamToShader(isBidirectional, $"_SPS_Tri_{prefix}_IsBidirectional", r.renderer);
                                 }
                             }
                         }

--- a/com.vrcfury.vrcfury/Editor/VF/Inspector/VRCFuryHapticSocketEditor.cs
+++ b/com.vrcfury.vrcfury/Editor/VF/Inspector/VRCFuryHapticSocketEditor.cs
@@ -367,9 +367,7 @@ namespace VF.Inspector {
         public static Tuple<VRCFuryHapticSocket.AddLight, Vector3, Quaternion> GetInfoFromLightsOrComponent(VRCFuryHapticSocket socket) {
             if (socket.addLight != VRCFuryHapticSocket.AddLight.None) {
                 var type = socket.addLight;
-                if (type == VRCFuryHapticSocket.AddLight.Auto)
-                    type = ShouldProbablyBeHole(socket) ? VRCFuryHapticSocket.AddLight.Hole :
-                        ShouldProbablyBeReversible(socket) ? VRCFuryHapticSocket.AddLight.RingBidirectional : VRCFuryHapticSocket.AddLight.Ring;
+                if (type == VRCFuryHapticSocket.AddLight.Auto) type = ShouldProbablyBeHole(socket) ? VRCFuryHapticSocket.AddLight.Hole : VRCFuryHapticSocket.AddLight.Ring;
                 var position = socket.position;
                 var rotation = Quaternion.Euler(socket.rotation);
                 return Tuple.Create(type, position, rotation);
@@ -448,12 +446,6 @@ namespace VF.Inspector {
         public static bool ShouldProbablyBeHole(VRCFuryHapticSocket socket) {
             if (HapticUtils.IsChildOfBone(socket.owner(), HumanBodyBones.Head)) return true;
             return ShouldProbablyHaveTouchZone(socket);
-        }
-
-        public static bool ShouldProbablyBeReversible(VRCFuryHapticSocket socket) {
-            if (HapticUtils.IsChildOfBone(socket.owner(), HumanBodyBones.LeftHand)) return true;
-            if (HapticUtils.IsChildOfBone(socket.owner(), HumanBodyBones.RightHand)) return true;
-            return false;
         }
 
         public static string GetName(VRCFuryHapticSocket socket) {

--- a/com.vrcfury.vrcfury/Runtime/VF/Component/VRCFuryHapticSocket.cs
+++ b/com.vrcfury.vrcfury/Runtime/VF/Component/VRCFuryHapticSocket.cs
@@ -9,6 +9,7 @@ namespace VF.Component {
             None,
             Hole,
             Ring,
+            RingBidirectional,
             Auto
         }
 
@@ -84,6 +85,9 @@ namespace VF.Component {
             if (fromVersion < 7) {
                 enableActiveAnimation = activeActions.actions.Count > 0;
             }
+            if (fromVersion < 8) {
+                if (addLight == AddLight.Ring) addLight = AddLight.RingBidirectional;
+            }
 #pragma warning restore 0612
             return false;
         }
@@ -105,7 +109,7 @@ namespace VF.Component {
         }
 
         public override int GetLatestVersion() {
-            return 7;
+            return 8;
         }
     }
 }

--- a/com.vrcfury.vrcfury/SPS/sps_main.cginc
+++ b/com.vrcfury.vrcfury/SPS/sps_main.cginc
@@ -19,6 +19,7 @@ void sps_apply_real(inout float3 vertex, inout float3 normal, uint vertexId, ino
 
 	float3 rootPos;
 	bool isRing;
+	bool isReversible;
 	float3 frontNormal;
 	bool found = false;
 	{
@@ -26,7 +27,7 @@ void sps_apply_real(inout float3 vertex, inout float3 normal, uint vertexId, ino
 		sps_tri_search(selfData, found, rootPos, isRing, frontNormal, color);
 		sps_tri_GetData(Other, otherData)
 		sps_tri_search(otherData, found, rootPos, isRing, frontNormal, color);
-		sps_light_search(found, rootPos, isRing, frontNormal, color);
+		sps_light_search(found, rootPos, isRing, isReversible, frontNormal, color);
 	}
 	if (!found) return;
 
@@ -34,8 +35,8 @@ void sps_apply_real(inout float3 vertex, inout float3 normal, uint vertexId, ino
 	float exitAngle = sps_angle_between(rootPos, float3(0,0,1));
 	float entranceAngle = SPS_PI - sps_angle_between(frontNormal, rootPos);
 
-	// Flip backward rings
-	if (isRing && entranceAngle > SPS_PI/2) {
+	// Flip backward reversible rings
+	if (isReversible && entranceAngle > SPS_PI/2) {
 		frontNormal *= -1;
 		entranceAngle = SPS_PI - entranceAngle;
 	}
@@ -52,13 +53,13 @@ void sps_apply_real(inout float3 vertex, inout float3 normal, uint vertexId, ino
 		applyLerp = min(applyLerp, 1-exitAngleTooSharp);
 
 		// Cancel if the entrance angle is too sharp
-		if (!isRing) {
+		if (!isReversible) {
 			const float allowedEntranceAngle = isRing ? 0.5 : 0.8;
 			const float entranceAngleTooSharp = entranceAngle > SPS_PI*allowedEntranceAngle ? 1 : 0;
 			applyLerp = min(applyLerp, 1-entranceAngleTooSharp);
 		}
 		
-		if (!isRing) {
+		if (!isReversible) {
 			// Uncancel if hilted in a hole
 			const float hiltedSphereRadius = 0.3;
 			const float inSphere = orfDistance > worldLength*hiltedSphereRadius ? 0 : 1;

--- a/com.vrcfury.vrcfury/SPS/sps_main.cginc
+++ b/com.vrcfury.vrcfury/SPS/sps_main.cginc
@@ -24,9 +24,9 @@ void sps_apply_real(inout float3 vertex, inout float3 normal, uint vertexId, ino
 	bool found = false;
 	{
 		sps_tri_GetData(Self, selfData)
-		sps_tri_search(selfData, found, rootPos, isRing, frontNormal, color);
+		sps_tri_search(selfData, found, rootPos, isRing, isReversible, frontNormal, color);
 		sps_tri_GetData(Other, otherData)
-		sps_tri_search(otherData, found, rootPos, isRing, frontNormal, color);
+		sps_tri_search(otherData, found, rootPos, isRing, isReversible, frontNormal, color);
 		sps_light_search(found, rootPos, isRing, isReversible, frontNormal, color);
 	}
 	if (!found) return;

--- a/com.vrcfury.vrcfury/SPS/sps_props.cginc
+++ b/com.vrcfury.vrcfury/SPS/sps_props.cginc
@@ -36,6 +36,7 @@ _SPS_Tri_Self_Front_Up("_SPS_Tri_Self_Front_Up", Float) = 0
 _SPS_Tri_Self_Front_Right("_SPS_Tri_Self_Front_Right", Float) = 0
 _SPS_Tri_Self_IsRing("_SPS_Tri_Self_IsRing", Float) = 0
 _SPS_Tri_Self_IsHole("_SPS_Tri_Self_IsHole", Float) = 0
+_SPS_Tri_Self_IsHole("_SPS_Tri_Self_IsBidirectional", Float) = 0
 
 _SPS_Tri_Other_Enabled("_SPS_Tri_Other_Enabled", Float) = 0
 _SPS_Tri_Other_Root_Center("_SPS_Tri_Other_Root_Center", Float) = 0
@@ -48,3 +49,4 @@ _SPS_Tri_Other_Front_Up("_SPS_Tri_Other_Front_Up", Float) = 0
 _SPS_Tri_Other_Front_Right("_SPS_Tri_Other_Front_Right", Float) = 0
 _SPS_Tri_Other_IsRing("_SPS_Tri_Other_IsRing", Float) = 0
 _SPS_Tri_Other_IsHole("_SPS_Tri_Other_IsHole", Float) = 0
+_SPS_Tri_Other_IsHole("_SPS_Tri_Other_IsBidirectional", Float) = 0

--- a/com.vrcfury.vrcfury/SPS/sps_tri.cginc
+++ b/com.vrcfury.vrcfury/SPS/sps_tri.cginc
@@ -14,7 +14,8 @@
     float _SPS_Tri_##prefix##_Front_Up;\
     float _SPS_Tri_##prefix##_Front_Right;\
     float _SPS_Tri_##prefix##_IsRing;\
-    float _SPS_Tri_##prefix##_IsHole;
+    float _SPS_Tri_##prefix##_IsHole;\
+    float _SPS_Tri_##prefix##_IsBidirectional;
 
 SPS_TRI_DEFINE(Self)
 SPS_TRI_DEFINE(Other)
@@ -31,6 +32,7 @@ struct SpsTriData {
     SpsTriCoords front;
     float isRing;
     float isHole;
+    float isBidirectional;
 };
 
 #define sps_tri_GetCoords(prefix,name) \
@@ -51,6 +53,7 @@ struct SpsTriData {
         name.front = tmpfront; \
         name.isRing = _SPS_Tri_##prefix##_IsRing; \
         name.isHole = _SPS_Tri_##prefix##_IsHole; \
+        name.isBidirectional = _SPS_Tri_##prefix##_IsBidirectional; \
     }
 
 bool sps_tri_isTouching(SpsTriCoords coords) {
@@ -82,6 +85,7 @@ void sps_tri_search(
     inout bool ioFound,
     inout float3 ioRootLocal,
     inout bool ioIsRing,
+    inout bool ioIsReversible,
     inout float3 ioRootNormal,
     inout float4 ioColor
 ) {
@@ -91,12 +95,14 @@ void sps_tri_search(
     const float3 front = sps_tri_triangulate(data.front);
     const bool isRing = data.root.center == data.isRing;
     const bool isHole = data.root.center == data.isHole;
+    const bool isBidirectional = data.root.center == data.isBidirectional;
     if (!isRing && !isHole) return;
 
     if (distance(root, front) > 0.1) return;
     if (ioFound && length(root) >= length(ioRootLocal)) return;
 
     ioIsRing = isRing;
+    ioIsReversible = isBidirectional;
     ioRootLocal = root;
     ioRootNormal = sps_normalize(front - root);
     ioFound = true;


### PR DESCRIPTION
While bidirectional ring sockets are useful for hands, rings sockets are also used where bidirectional support is either unneeded or unwanted.
Additionally, supporting bidirectional appears to require stricter limits on how the plug tracks the socket, vs holes

Use a slightly offset the range set to indicate if a socket is bidirectional, while still retaining compatibility with DPS & TPS

~~Additionally, we change the equation for light range to a supposedly more accurate one as per this [post from a Unity dev](https://forum.unity.com/threads/point-light-in-v-f-shader.499717/#post-9052987)~~ (Already in main)

Note that this makes ring orifices non reversible by default.

~~TODO Decide what we want to do on upgrade,
Do we want to change all rings to bidirectional? or only those on the hands?~~
All existing VRCFuryHapticSocket Rings are set as bidirectional, (as VRCFArmatureUtils uses editor only APIs)

```
The changes made in this contribution are free and unencumbered software
released into the public domain.

Anyone is free to copy, modify, publish, use, compile, sell, or
distribute this software, either in source code form or as a compiled
binary, for any purpose, commercial or non-commercial, and by any
means.

In jurisdictions that recognize copyright laws, the author or authors
of this software dedicate any and all copyright interest in the
software to the public domain. We make this dedication for the benefit
of the public at large and to the detriment of our heirs and
successors. We intend this dedication to be an overt act of
relinquishment in perpetuity of all present and future rights to this
software under copyright law.

THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND,
EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF
MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT.
IN NO EVENT SHALL THE AUTHORS BE LIABLE FOR ANY CLAIM, DAMAGES OR
OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE,
ARISING FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR
OTHER DEALINGS IN THE SOFTWARE.

For more information, please refer to <https://unlicense.org>
```