### PR TITLE
Set additive layer to 'None', instead of the default.

### DIFF
--- a/com.vrcfury.vrcfury/Editor/VF/Builder/VRCFuryBuilder.cs
+++ b/com.vrcfury.vrcfury/Editor/VF/Builder/VRCFuryBuilder.cs
@@ -129,6 +129,7 @@ public class VRCFuryBuilder {
         AddBuilder(typeof(CleanupLegacyBuilder));
         AddBuilder(typeof(RemoveJunkAnimatorsBuilder));
         AddBuilder(typeof(FixDoubleFxBuilder));
+        AddBuilder(typeof(DefaultAdditiveLayerFixBuilder));
         AddBuilder(typeof(FixWriteDefaultsBuilder));
         AddBuilder(typeof(BakeGlobalCollidersBuilder));
         AddBuilder(typeof(ControllerConflictBuilder));

--- a/com.vrcfury.vrcfury/Editor/VF/Feature/Base/FeatureOrder.cs
+++ b/com.vrcfury.vrcfury/Editor/VF/Feature/Base/FeatureOrder.cs
@@ -5,7 +5,6 @@ namespace VF.Feature.Base {
         
         // Needs to happen before everything
         FixDoubleFx,
-        RemoveDefaultedAdditiveLayer,
         
         // Needs to happen before ForceObjectState
         FullControllerToggle,
@@ -101,6 +100,7 @@ namespace VF.Feature.Base {
         MarkThingsAsDirtyJustInCase,
         
         RemoveJunkAnimators,
+        RemoveDefaultedAdditiveLayer,
         
         // Needs to be at the very end, because it places immutable clips into the avatar
         RestoreProxyClips,

--- a/com.vrcfury.vrcfury/Editor/VF/Feature/Base/FeatureOrder.cs
+++ b/com.vrcfury.vrcfury/Editor/VF/Feature/Base/FeatureOrder.cs
@@ -5,6 +5,7 @@ namespace VF.Feature.Base {
         
         // Needs to happen before everything
         FixDoubleFx,
+        RemoveDefaultedAdditiveLayer,
         
         // Needs to happen before ForceObjectState
         FullControllerToggle,

--- a/com.vrcfury.vrcfury/Editor/VF/Feature/DefaultAdditiveLayerFixBuilder.cs
+++ b/com.vrcfury.vrcfury/Editor/VF/Feature/DefaultAdditiveLayerFixBuilder.cs
@@ -1,0 +1,26 @@
+using System.Collections.Generic;
+using System.Linq;
+using UnityEngine;
+using VF.Builder.Exceptions;
+using VF.Feature.Base;
+using VRC.SDK3.Avatars.Components;
+
+namespace VF.Feature {
+    public class DefaultAdditiveLayerFixBuilder : FeatureBuilder {
+        [FeatureBuilderAction(FeatureOrder.RemoveDefaultedAdditiveLayer)]
+        public void Apply() {
+            var descriptor = avatarObject.GetComponent<VRCAvatarDescriptor>();
+
+            for (int i=0; i<descriptor.baseAnimationLayers.Length; i++) {
+                var layer = descriptor.baseAnimationLayers[i];
+                if (
+                    layer.type == VRCAvatarDescriptor.AnimLayerType.Additive && 
+                    layer.isDefault &&
+                    layer.animatorController == null
+                ) {
+                    descriptor.baseAnimationLayers[i].isDefault = false;
+                }
+            }
+        }
+    }
+}

--- a/com.vrcfury.vrcfury/Editor/VF/Feature/DefaultAdditiveLayerFixBuilder.cs.meta
+++ b/com.vrcfury.vrcfury/Editor/VF/Feature/DefaultAdditiveLayerFixBuilder.cs.meta
@@ -1,0 +1,11 @@
+fileFormatVersion: 2
+guid: 9fee083840bd8b44b8b8326a94c49ab9
+MonoImporter:
+  externalObjects: {}
+  serializedVersion: 2
+  defaultReferences: []
+  executionOrder: 0
+  icon: {instanceID: 0}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 


### PR DESCRIPTION
This mitigates the blendshape tripling bug for WD-ON avatars, the default additive layer seems (maybe) to always be WD-OFF, regardless of the state of the rest of the controllers. This seems to cause blendshape tripling when a gesture layer is present and the avatar is WD-ON. (Specifically, when an blendshape with a non-zero default is animated in the FX layer, but the controller is not currently animating it)

This bug is triggered on several avatar bases when adding a Fix WD builder in Auto mode.
Having the additive layer nulled out or with a controller that is processed by VRCF, removing the gesture layer, or using WD-OFF seems to mitigate this.

This change simply removes the isDefault tag on additive layers when they have no controller assigned.

```
The changes made in this contribution are free and unencumbered software
released into the public domain.

Anyone is free to copy, modify, publish, use, compile, sell, or
distribute this software, either in source code form or as a compiled
binary, for any purpose, commercial or non-commercial, and by any
means.

In jurisdictions that recognize copyright laws, the author or authors
of this software dedicate any and all copyright interest in the
software to the public domain. We make this dedication for the benefit
of the public at large and to the detriment of our heirs and
successors. We intend this dedication to be an overt act of
relinquishment in perpetuity of all present and future rights to this
software under copyright law.

THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND,
EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF
MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT.
IN NO EVENT SHALL THE AUTHORS BE LIABLE FOR ANY CLAIM, DAMAGES OR
OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE,
ARISING FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR
OTHER DEALINGS IN THE SOFTWARE.

For more information, please refer to <https://unlicense.org>
```