### PR TITLE
SPS: Add option for local scale socket units 

### DIFF
--- a/com.vrcfury.vrcfury/CONTRIBUTING.md
+++ b/com.vrcfury.vrcfury/CONTRIBUTING.md
@@ -73,6 +73,7 @@ For more information, please refer to <https://unlicense.org>
 * TheLastRar
   * Contributed attempts to fix light slot 4 breakage for DPS tip lights (unused)
   * Added scaling of legacy DPS tip light intensity
+  * Add option for using local space for socket units
 * Toys0125
   * Added Poiyomi UV Tile action type
 * wholesomevr

--- a/com.vrcfury.vrcfury/Editor/VF/Feature/BakeHapticSocketsBuilder.cs
+++ b/com.vrcfury.vrcfury/Editor/VF/Feature/BakeHapticSocketsBuilder.cs
@@ -194,7 +194,8 @@ namespace VF.Feature {
                             socket.depthActions,
                             socket.owner(),
                             animRoot,
-                            name
+                            name,
+                            socket.unitsInMeters
                         );
                     }
                 } catch (Exception e) {

--- a/com.vrcfury.vrcfury/Editor/VF/Inspector/VRCFuryHapticSocketEditor.cs
+++ b/com.vrcfury.vrcfury/Editor/VF/Inspector/VRCFuryHapticSocketEditor.cs
@@ -74,12 +74,13 @@ namespace VF.Inspector {
                     "If you provide a non-static (moving) animation clip, the clip will run from start " +
                     "to end depending on penetration depth. Otherwise, it will animate from 'off' to 'on' depending on depth."));
                 
-                da.Add(VRCFuryEditorUtils.Info(
+                var unscaledUnitsProp = serializedObject.FindProperty("unitsInMeters");
+                da.Add(VRCFuryEditorUtils.RefreshOnChange(() => VRCFuryEditorUtils.Info(
                     "Distance = 0 : Tip of plug is touching socket\n" +
                     "Distance > 0 : Tip of plug is outside socket\n" +
                     "Distance < 0 = Tip of plug is inside socket\n" +
-                    "1 Unit is 1 Meter (~3 feet)"
-                ));
+                    (unscaledUnitsProp.boolValue ? "1 Unit is 1 Meter (~3.28 feet)" : $"1 Unit is {target.transform.lossyScale.z} Meter(s) (~{Math.Round(target.transform.lossyScale.z * 3.28, 2)} feet)")
+                ), unscaledUnitsProp));
 
                 da.Add(VRCFuryEditorUtils.List(serializedObject.FindProperty("depthActions"), (i, prop) => {
                     var c = new VisualElement();
@@ -126,6 +127,7 @@ namespace VF.Inspector {
                 value = false,
             };
             container.Add(adv);
+            adv.Add(VRCFuryEditorUtils.BetterCheckbox(serializedObject.FindProperty("unitsInMeters"), "Units are in world-space"));
             adv.Add(VRCFuryEditorUtils.BetterProp(serializedObject.FindProperty("position"), "Position"));
             adv.Add(VRCFuryEditorUtils.BetterProp(serializedObject.FindProperty("rotation"), "Rotation"));
             //adv.Add(VRCFuryEditorUtils.BetterProp(serializedObject.FindProperty("channel"), "Channel"));
@@ -352,7 +354,7 @@ namespace VF.Inspector {
             if (!enableHandTouchZone) {
                 return null;
             }
-            var length = socket.length;
+            var length = socket.length * (socket.unitsInMeters ? 1f : socket.transform.lossyScale.z); ;
             if (length <= 0) length = 0.25f;
             var radius = length / 2.5f;
             return Tuple.Create(length, radius);

--- a/com.vrcfury.vrcfury/Editor/VF/Service/HapticAnimContactsService.cs
+++ b/com.vrcfury.vrcfury/Editor/VF/Service/HapticAnimContactsService.cs
@@ -102,7 +102,8 @@ namespace VF.Service {
             ICollection<VRCFuryHapticSocket.DepthAction> actions,
             VFGameObject socketOwner,
             VFGameObject animRoot,
-            string name
+            string name,
+            bool worldScale
         ) {
             var fx = avatarManager.GetFx();
 
@@ -111,8 +112,8 @@ namespace VF.Service {
                 if (cache.TryGetValue(allowSelf, out var cached)) return cached;
 
                 var prefix = $"{name}/Anim{(allowSelf ? "" : "Others")}";
-                var maxDist = Math.Max(0, actions.Max(a => Math.Max(a.startDistance, a.endDistance)));
-                var minDist = Math.Min(0, actions.Min(a => Math.Min(a.startDistance, a.endDistance)));
+                var maxDist = Math.Max(0, actions.Max(a => Math.Max(a.startDistance, a.endDistance))) * (worldScale ? 1f : animRoot.transform.lossyScale.z);
+                var minDist = Math.Min(0, actions.Min(a => Math.Min(a.startDistance, a.endDistance))) * (worldScale ? 1f : animRoot.transform.lossyScale.z);
                 var outerRadius = Math.Max(0.01f, maxDist);
                 var outer = CreateFrontBack($"{prefix}/Outer", animRoot, outerRadius, allowSelf, HapticUtils.CONTACT_PEN_MAIN);
 
@@ -156,7 +157,8 @@ namespace VF.Service {
                 var mapped = smoothing.Map(
                     $"{prefix}/Mapped",
                     unsmoothed,
-                    depthAction.startDistance, depthAction.endDistance,
+                    depthAction.startDistance * (worldScale ? 1f : animRoot.transform.lossyScale.z),
+                    depthAction.endDistance * (worldScale ? 1f : animRoot.transform.lossyScale.z),
                     0, 1
                 );
                 var smoothed = smoothing.Smooth(

--- a/com.vrcfury.vrcfury/Runtime/VF/Component/VRCFuryHapticSocket.cs
+++ b/com.vrcfury.vrcfury/Runtime/VF/Component/VRCFuryHapticSocket.cs
@@ -22,6 +22,7 @@ namespace VF.Component {
         public new string name;
         public EnableTouchZone enableHandTouchZone2 = EnableTouchZone.Auto;
         public float length;
+        public bool unitsInMeters = true;
         public bool addMenuItem = true;
         public bool enableAuto = true;
         public Vector3 position;


### PR DESCRIPTION
Adds a "Units are in world-space" checkbox, default on.
Unchecking will instead consider the sockets scale (particularly along the Z axis, but sockets only support uniform scale anyway)

This is useful for prefabs that contain depth animations, as the prefab object may not used at the same scale the prefab was created for

```
The changes made in this contribution are free and unencumbered software
released into the public domain.

Anyone is free to copy, modify, publish, use, compile, sell, or
distribute this software, either in source code form or as a compiled
binary, for any purpose, commercial or non-commercial, and by any
means.

In jurisdictions that recognize copyright laws, the author or authors
of this software dedicate any and all copyright interest in the
software to the public domain. We make this dedication for the benefit
of the public at large and to the detriment of our heirs and
successors. We intend this dedication to be an overt act of
relinquishment in perpetuity of all present and future rights to this
software under copyright law.

THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND,
EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF
MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT.
IN NO EVENT SHALL THE AUTHORS BE LIABLE FOR ANY CLAIM, DAMAGES OR
OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE,
ARISING FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR
OTHER DEALINGS IN THE SOFTWARE.

For more information, please refer to <https://unlicense.org>
```