### PR TITLE
BlendShapeLink: Add exact match option

### DIFF
--- a/com.vrcfury.vrcfury/CONTRIBUTING.md
+++ b/com.vrcfury.vrcfury/CONTRIBUTING.md
@@ -73,6 +73,7 @@ For more information, please refer to <https://unlicense.org>
 * TheLastRar
   * Contributed attempts to fix light slot 4 breakage for DPS tip lights (unused)
   * Added scaling of legacy DPS tip light intensity
+  * Add option for exact matching in BlendShapeLink
 * Toys0125
   * Added Poiyomi UV Tile action type
 * wholesomevr

--- a/com.vrcfury.vrcfury/Runtime/VF/Model/Feature.cs
+++ b/com.vrcfury.vrcfury/Runtime/VF/Model/Feature.cs
@@ -608,6 +608,7 @@ namespace VF.Model.Feature {
         public List<GameObject> objs;
         public string baseObj;
         public bool includeAll = true;
+        public bool exactMatch = false;
         public List<Exclude> excludes = new List<Exclude>();
         public List<Include> includes = new List<Include>();
         


### PR DESCRIPTION
Add option to disable fuzzy blendshape matching

Useful in situations where the target mesh has a subset of the base mesh's blendshapes but include all is used, as fuzzy matching can be over eager in finding a link.

```
The changes made in this contribution are free and unencumbered software
released into the public domain.

Anyone is free to copy, modify, publish, use, compile, sell, or
distribute this software, either in source code form or as a compiled
binary, for any purpose, commercial or non-commercial, and by any
means.

In jurisdictions that recognize copyright laws, the author or authors
of this software dedicate any and all copyright interest in the
software to the public domain. We make this dedication for the benefit
of the public at large and to the detriment of our heirs and
successors. We intend this dedication to be an overt act of
relinquishment in perpetuity of all present and future rights to this
software under copyright law.

THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND,
EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF
MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT.
IN NO EVENT SHALL THE AUTHORS BE LIABLE FOR ANY CLAIM, DAMAGES OR
OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE,
ARISING FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR
OTHER DEALINGS IN THE SOFTWARE.

For more information, please refer to <https://unlicense.org>
```