### PR TITLE
Set the Editor Test Copy's Animator controller to the generated FX layer

### DIFF
--- a/com.vrcfury.vrcfury/CONTRIBUTING.md
+++ b/com.vrcfury.vrcfury/CONTRIBUTING.md
@@ -64,6 +64,7 @@ For more information, please refer to <https://unlicense.org>
 * nullstalgia
   * Added option for Toggles to use momentary push buttons
   * Prevented SPS toggle from disabling SPS autorig physbone
+  * Set the Editor Test Copy's Animator controller to the generated FX layer
 * Raphiiko
   * Added global parameters for Toggles
 * TayouVR

--- a/com.vrcfury.vrcfury/Editor/VF/Menu/VRCFuryTestCopyMenuItem.cs
+++ b/com.vrcfury.vrcfury/Editor/VF/Menu/VRCFuryTestCopyMenuItem.cs
@@ -1,8 +1,10 @@
 using System.Linq;
 using UnityEditor;
+using UnityEngine;
 using UnityEngine.SceneManagement;
 using VF.Builder;
 using VF.Model;
+using VRC.SDK3.Avatars.Components;
 
 namespace VF.Menu {
     public static class VRCFuryTestCopyMenuItem {
@@ -38,6 +40,14 @@ namespace VF.Menu {
             if (result) {
                 VRCFuryBuilder.StripAllVrcfComponents(clone);
                 clone.AddComponent<VRCFuryTest>();
+                // Set the clone's Animator's controller to our generated FX layer
+                // It can be retrieved from the resulting object's VRC avatar descriptor
+                var avatar = clone.GetComponent<VRCAvatarDescriptor>();
+                var (isDefault, existingController) = VRCAvatarUtils.GetAvatarController(avatar, VRCAvatarDescriptor.AnimLayerType.FX);
+                var animator = clone.GetComponent<Animator>();
+                if (animator && !isDefault && existingController != null) {
+                    animator.runtimeAnimatorController = existingController;
+                }
                 Selection.SetActiveObjectWithContext(clone, clone);
             } else {
                 clone.Destroy();


### PR DESCRIPTION
This is for when I'm working on something and I want to see how the optimizers and other tools' end result is, without needing to navigate the project view or Avatar Descriptor to find *and then open* the new FX layer in the Animator view.