### PR TITLE
SPS: Include toPath in MoveMenuItem & path in SetIcon in naming upgrade

### DIFF
--- a/com.vrcfury.vrcfury/Runtime/VF/Model/Feature.cs
+++ b/com.vrcfury.vrcfury/Runtime/VF/Model/Feature.cs
@@ -534,11 +534,17 @@ namespace VF.Model.Feature {
                     fromPath = "SPS" + fromPath.Substring(7);
                 }
             }
+
+            if (fromVersion < 3) {
+                if (toPath.StartsWith("Sockets/") || toPath == "Sockets") {
+                    toPath = "SPS" + toPath.Substring(7);
+                }
+            }
             return false;
         }
 
         public override int GetLatestVersion() {
-            return 2;
+            return 3;
         }
     }
     
@@ -634,6 +640,19 @@ namespace VF.Model.Feature {
     public class SetIcon : NewFeatureModel {
         public string path;
         public GuidTexture2d icon;
+        
+        public override bool Upgrade(int fromVersion) {
+            if (fromVersion < 1) {
+                if (path.StartsWith("Sockets/") || path == "Sockets") {
+                    path = "SPS" + path.Substring(7);
+                }
+            }
+            return false;
+        }
+
+        public override int GetLatestVersion() {
+            return 1;
+        }
     }
     
     [Serializable]


### PR DESCRIPTION
Since the name change from Sockets to SPS, this PR adds upgrading the toPath field in MoveMenuItem & path in SetIcon for cases like this:
![image](https://github.com/VRCFury/VRCFury/assets/137558450/c1e9a632-b044-4d43-8bb7-09c82d2fb88c)



```
The changes made in this contribution are free and unencumbered software
released into the public domain.

Anyone is free to copy, modify, publish, use, compile, sell, or
distribute this software, either in source code form or as a compiled
binary, for any purpose, commercial or non-commercial, and by any
means.

In jurisdictions that recognize copyright laws, the author or authors
of this software dedicate any and all copyright interest in the
software to the public domain. We make this dedication for the benefit
of the public at large and to the detriment of our heirs and
successors. We intend this dedication to be an overt act of
relinquishment in perpetuity of all present and future rights to this
software under copyright law.

THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND,
EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF
MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT.
IN NO EVENT SHALL THE AUTHORS BE LIABLE FOR ANY CLAIM, DAMAGES OR
OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE,
ARISING FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR
OTHER DEALINGS IN THE SOFTWARE.

For more information, please refer to <https://unlicense.org/>
```