### PR TITLE
[Armature Link] Move physbone colliders to new bones if they will stop existing

### DIFF
--- a/com.vrcfury.vrcfury/Editor/VF/Service/ObjectMoveService.cs
+++ b/com.vrcfury.vrcfury/Editor/VF/Service/ObjectMoveService.cs
@@ -33,19 +33,19 @@ namespace VF.Service {
             DirectRewrite(oldPath, newPath);
         }
 
-        public void DirectRewrite(GameObject oldObj, GameObject newObj) {
+        public void DirectRewrite(GameObject oldObj, GameObject newObj, Type rewriteType = null) {
             var oldPath = clipBuilder.GetPath(oldObj);
             var newPath = clipBuilder.GetPath(newObj);
-            DirectRewrite(oldPath, newPath);
+            DirectRewrite(oldPath, newPath, rewriteType);
         }
         
-        private void DirectRewrite(string from, string to) {
+        private void DirectRewrite(string from, string to, Type rewriteType = null) {
             var rewriter = AnimationRewriter.RewritePath(path => {
                 if (path.StartsWith(from + "/") || path == from) {
                     path = to + path.Substring(from.Length);
                 }
                 return path;
-            });
+            }, rewriteType);
 
             foreach (var controller in manager.GetAllUsedControllers()) {
                 ((AnimatorController)controller.GetRaw()).Rewrite(rewriter);

--- a/com.vrcfury.vrcfury/Editor/VF/Utils/AnimationRewriter.cs
+++ b/com.vrcfury.vrcfury/Editor/VF/Utils/AnimationRewriter.cs
@@ -6,8 +6,9 @@ using UnityEngine;
 namespace VF.Utils {
     public class AnimationRewriter {
         public delegate (EditorCurveBinding, FloatOrObjectCurve, bool) CurveRewriter(EditorCurveBinding binding, FloatOrObjectCurve curve);
-        public static AnimationRewriter RewritePath(Func<string, string> rewrite) {
+        public static AnimationRewriter RewritePath(Func<string, string> rewrite, Type rewriteType = null) {
             return RewriteBinding(binding => {
+                if (rewriteType != null && binding.type != rewriteType) return binding;
                 var newPath = rewrite(binding.path);
                 if (newPath == null) return null;
                 if (newPath == binding.path) return binding;


### PR DESCRIPTION
Having a physbone colliders on a armature-linked bone that has a corresponding bone on the base will not build, as the bone with the collider component will stop existing. This style of collider use is common in modular-avatars prefabs, and also when separating clothing into prefabs. This change makes it significantly easier to use these prefabs.

This change creates a new object under the base bone to contain the collider, rewrites all references to point to the new collider, and deletes the old one.

Changes were made in ObjectMoveService and AnimationRewriter to enable rewriting only bindings for the colliders.

```
The changes made in this contribution are free and unencumbered software
released into the public domain.

Anyone is free to copy, modify, publish, use, compile, sell, or
distribute this software, either in source code form or as a compiled
binary, for any purpose, commercial or non-commercial, and by any
means.

In jurisdictions that recognize copyright laws, the author or authors
of this software dedicate any and all copyright interest in the
software to the public domain. We make this dedication for the benefit
of the public at large and to the detriment of our heirs and
successors. We intend this dedication to be an overt act of
relinquishment in perpetuity of all present and future rights to this
software under copyright law.

THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND,
EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF
MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT.
IN NO EVENT SHALL THE AUTHORS BE LIABLE FOR ANY CLAIM, DAMAGES OR
OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE,
ARISING FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR
OTHER DEALINGS IN THE SOFTWARE.

For more information, please refer to <https://unlicense.org>
```