### PR TITLE
armature link - check for transform path within humanoid bone

### DIFF
--- a/com.vrcfury.vrcfury/Editor/VF/Feature/ArmatureLinkBuilder.cs
+++ b/com.vrcfury.vrcfury/Editor/VF/Feature/ArmatureLinkBuilder.cs
@@ -263,20 +263,27 @@ namespace VF.Feature {
 
             VFGameObject avatarBone = null;
 
-            if (string.IsNullOrWhiteSpace(model.bonePathOnAvatar)) {
-                try {
-                    avatarBone = VRCFArmatureUtils.FindBoneOnArmatureOrException(avatarObject, model.boneOnAvatar);
-                } catch (Exception) {
-                    foreach (var fallback in model.fallbackBones) {
-                        avatarBone = VRCFArmatureUtils.FindBoneOnArmatureOrNull(avatarObject, fallback);
-                        if (avatarBone) break;
-                    }
-                    if (!avatarBone) {
-                        throw;
-                    }
+            try {
+                avatarBone = VRCFArmatureUtils.FindBoneOnArmatureOrException(avatarObject, model.boneOnAvatar);
+            } catch (Exception) {
+                foreach (var fallback in model.fallbackBones) {
+                    avatarBone = VRCFArmatureUtils.FindBoneOnArmatureOrNull(avatarObject, fallback);
+                    if (avatarBone) break;
                 }
-            } else {
-                avatarBone = avatarObject.transform.Find(model.bonePathOnAvatar)?.gameObject;
+                if (!avatarBone) {
+                    throw;
+                }
+            }
+            
+            if (!string.IsNullOrWhiteSpace(model.bonePathOnAvatar)) {
+                // Check for path within humanoid bone
+                // if nothing is there, check from avatar root instead
+                if (avatarBone?.transform.Find(model.bonePathOnAvatar)?.gameObject) {
+                    avatarBone = avatarBone?.transform.Find(model.bonePathOnAvatar)?.gameObject;
+                } else {
+                    avatarBone = avatarObject.transform.Find(model.bonePathOnAvatar)?.gameObject;
+                }
+
                 if (avatarBone == null) {
                     throw new VRCFBuilderException(
                         "ArmatureLink failed to find " + model.bonePathOnAvatar + " bone on avatar.");


### PR DESCRIPTION
I've always found it a bit annoying to type out the entire path if you need to link to e.g. a empty transform within some bone, or into a twist bone for example.
This should change the armature link - reparent root mode to behave like so:
```cs
// this is simplified pseudocode to explain the logic
avatarBone = FindHumanoidBone(); // find humanoid bone

if (transformPath.isNotNull()) {
    if (avatarBone.Find(transformPath)) { 
        avatarBone = avatarBone.Find(transformPath); // find transform relative to humanoid bone
    } else { 
        avatarBone = avatarObject.Find(transformPath); // find transform relative to avatar root
    } 
}
```
		
## example:
this setup
![image](https://github.com/VRCFury/VRCFury/assets/31988415/e19de474-1976-4ba3-a1e7-3659afec177a)
moves the object here:
![image](https://github.com/VRCFury/VRCFury/assets/31988415/58f75330-aed8-44a1-aed1-d49e3fead5a4)

```
The changes made in this contribution are free and unencumbered software
released into the public domain.

Anyone is free to copy, modify, publish, use, compile, sell, or
distribute this software, either in source code form or as a compiled
binary, for any purpose, commercial or non-commercial, and by any
means.

In jurisdictions that recognize copyright laws, the author or authors
of this software dedicate any and all copyright interest in the
software to the public domain. We make this dedication for the benefit
of the public at large and to the detriment of our heirs and
successors. We intend this dedication to be an overt act of
relinquishment in perpetuity of all present and future rights to this
software under copyright law.

THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND,
EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF
MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT.
IN NO EVENT SHALL THE AUTHORS BE LIABLE FOR ANY CLAIM, DAMAGES OR
OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE,
ARISING FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR
OTHER DEALINGS IN THE SOFTWARE.

For more information, please refer to <https://unlicense.org/>
```

## This changes code in the same place as #142, merge that first, I'll rebase this by then. Unless you wanna do that