### PR TITLE
Add Set Global Param Action

### DIFF
--- a/com.vrcfury.vrcfury/Editor/VF/Feature/CleanupEmptyLayersBuilder.cs
+++ b/com.vrcfury.vrcfury/Editor/VF/Feature/CleanupEmptyLayersBuilder.cs
@@ -26,6 +26,9 @@ namespace VF.Feature {
                         if (binding.path == "__vrcf_length") {
                             return null;
                         }
+                        if (binding.path == "__vrcf_global_param") {
+                            return null;
+                        }
                         if (!binding.IsValid(avatarObject)) {
                             removedBindings.Add($"{binding.PrettyString()} from {clip.name}");
                             return null;

--- a/com.vrcfury.vrcfury/Editor/VF/Feature/DirectTreeOptimizerBuilder.cs
+++ b/com.vrcfury.vrcfury/Editor/VF/Feature/DirectTreeOptimizerBuilder.cs
@@ -144,6 +144,10 @@ namespace VF.Feature {
                         AddDebug($"Not optimizing (contains {states.Length} states)");
                         continue;
                     }
+                    if (states.Where(s => s.state.motion as AnimationClip).Any(s => (s.state.motion as AnimationClip).GetAllCurves().Any(c => c.Item1.path == "__vrcf_global_param"))) {
+                        AddDebug("Not optimizing (contains set global param)");
+                        continue;
+                    }
                     
                     var state0 = states[0].state;
                     var state1 = states[1].state;

--- a/com.vrcfury.vrcfury/Editor/VF/Inspector/VRCFuryActionEditor.cs
+++ b/com.vrcfury.vrcfury/Editor/VF/Inspector/VRCFuryActionEditor.cs
@@ -632,6 +632,32 @@ public class VRCFuryActionDrawer : PropertyDrawer {
 
                 return row;
             }
+            case nameof(SetGlobalParamAction): {
+                var row = new VisualElement {
+                    style = {
+                        flexDirection = FlexDirection.Row,
+                        alignItems = Align.FlexStart
+                    }
+                };
+
+                var label = new Label("Set a Global Param") {
+                    style = {
+                        flexGrow = 0,
+                        flexBasis = 120
+                    }
+                };
+                row.Add(label);
+
+                var propField = VRCFuryEditorUtils.Prop(prop.FindPropertyRelative("param"));
+                propField.style.flexGrow = 1;
+                row.Add(propField);
+                
+                var valueField = VRCFuryEditorUtils.Prop(prop.FindPropertyRelative("value"));
+                valueField.style.flexBasis = 30;
+                row.Add(valueField);
+
+                return row;
+            }
         }
 
         return VRCFuryEditorUtils.WrappedLabel($"Unknown action type: {type}");

--- a/com.vrcfury.vrcfury/Editor/VF/Inspector/VRCFuryActionEditor.cs
+++ b/com.vrcfury.vrcfury/Editor/VF/Inspector/VRCFuryActionEditor.cs
@@ -648,6 +648,10 @@ public class VRCFuryActionDrawer : PropertyDrawer {
                 };
                 row.Add(label);
 
+                var typeField = VRCFuryEditorUtils.Prop(prop.FindPropertyRelative("paramType"));
+                typeField.style.flexBasis = 100;
+                row.Add(typeField);
+
                 var propField = VRCFuryEditorUtils.Prop(prop.FindPropertyRelative("param"));
                 propField.style.flexGrow = 1;
                 row.Add(propField);

--- a/com.vrcfury.vrcfury/Editor/VF/Inspector/VRCFuryStateEditor.cs
+++ b/com.vrcfury.vrcfury/Editor/VF/Inspector/VRCFuryStateEditor.cs
@@ -45,6 +45,8 @@ public class VRCFuryStateEditor {
                 () => { VRCFuryEditorUtils.AddToList(list, entry => entry.managedReferenceValue = new BlockBlinkingAction()); });
             menu.AddItem(new GUIContent("Reset Physbone"), false,
                 () => { VRCFuryEditorUtils.AddToList(list, entry => entry.managedReferenceValue = new ResetPhysboneAction()); });
+             menu.AddItem(new GUIContent("Set a Global Parameter"), false,
+                () => { VRCFuryEditorUtils.AddToList(list, entry => entry.managedReferenceValue = new SetGlobalParamAction()); });
             menu.ShowAsContext();
         }
 

--- a/com.vrcfury.vrcfury/Editor/VF/Service/ActionClipService.cs
+++ b/com.vrcfury.vrcfury/Editor/VF/Service/ActionClipService.cs
@@ -245,6 +245,16 @@ namespace VF.Service {
                         }
                         break;
                     }
+                    case SetGlobalParamAction globalParamAction: {
+                        if (string.IsNullOrWhiteSpace(globalParamAction.param))
+                            break;
+                        if (string.IsNullOrWhiteSpace(globalParamAction.value))
+                            break;
+
+                        var value = float.Parse(globalParamAction.value);
+                        onClip.SetConstant(EditorCurveBinding.FloatCurve("Global Param", typeof(Animator), globalParamAction.param), value);
+                        break;
+                    }
                 }
             }
 

--- a/com.vrcfury.vrcfury/Editor/VF/Service/ActionClipService.cs
+++ b/com.vrcfury.vrcfury/Editor/VF/Service/ActionClipService.cs
@@ -251,8 +251,32 @@ namespace VF.Service {
                         if (string.IsNullOrWhiteSpace(globalParamAction.value))
                             break;
 
-                        var value = float.Parse(globalParamAction.value);
-                        onClip.SetConstant(EditorCurveBinding.FloatCurve("Global Param", typeof(Animator), globalParamAction.param), value);
+                        string checkValue = "";
+
+                        switch(globalParamAction.paramType) {
+                            case SetGlobalParamAction.ParamType.boolParam:
+                                fx.NewBool(globalParamAction.param, synced: false, saved: false, def: false, usePrefix: false);
+                                if (globalParamAction.value.ToLower().Contains("t")) checkValue = "1";
+                                else if (globalParamAction.value.ToLower().Contains("f")) checkValue = "0";
+                                else checkValue = globalParamAction.value;
+                                break;
+                            case SetGlobalParamAction.ParamType.intParam:
+                                fx.NewInt(globalParamAction.param, synced: false, saved: false, def: 0, usePrefix: false);
+                                checkValue = globalParamAction.value;
+                                break;
+                            case SetGlobalParamAction.ParamType.floatParam:
+                                fx.NewFloat(globalParamAction.param, synced: false, saved: false, def: 0, usePrefix: false);
+                                checkValue = globalParamAction.value;
+                                break;
+                        }
+                        try {
+                            var value = float.Parse(checkValue);
+                            onClip.SetConstant(EditorCurveBinding.FloatCurve("__vrcf_global_param", typeof(Animator), globalParamAction.param), value);
+                        } catch {
+                            var e = new Exception($"Failed to parse global paramter value for {globalParamAction.param}.");
+                            Debug.LogError(e);
+                            throw e;
+                        }
                         break;
                     }
                 }

--- a/com.vrcfury.vrcfury/Editor/VF/Service/ActionClipService.cs
+++ b/com.vrcfury.vrcfury/Editor/VF/Service/ActionClipService.cs
@@ -248,35 +248,8 @@ namespace VF.Service {
                     case SetGlobalParamAction globalParamAction: {
                         if (string.IsNullOrWhiteSpace(globalParamAction.param))
                             break;
-                        if (string.IsNullOrWhiteSpace(globalParamAction.value))
-                            break;
 
-                        string checkValue = "";
-
-                        switch(globalParamAction.paramType) {
-                            case SetGlobalParamAction.ParamType.boolParam:
-                                fx.NewBool(globalParamAction.param, synced: false, saved: false, def: false, usePrefix: false);
-                                if (globalParamAction.value.ToLower().Contains("t")) checkValue = "1";
-                                else if (globalParamAction.value.ToLower().Contains("f")) checkValue = "0";
-                                else checkValue = globalParamAction.value;
-                                break;
-                            case SetGlobalParamAction.ParamType.intParam:
-                                fx.NewInt(globalParamAction.param, synced: false, saved: false, def: 0, usePrefix: false);
-                                checkValue = globalParamAction.value;
-                                break;
-                            case SetGlobalParamAction.ParamType.floatParam:
-                                fx.NewFloat(globalParamAction.param, synced: false, saved: false, def: 0, usePrefix: false);
-                                checkValue = globalParamAction.value;
-                                break;
-                        }
-                        try {
-                            var value = float.Parse(checkValue);
-                            onClip.SetConstant(EditorCurveBinding.FloatCurve("__vrcf_global_param", typeof(Animator), globalParamAction.param), value);
-                        } catch {
-                            var e = new Exception($"Failed to parse global paramter value for {globalParamAction.param}.");
-                            Debug.LogError(e);
-                            throw e;
-                        }
+                        onClip.SetConstant(EditorCurveBinding.FloatCurve("__vrcf_global_param", typeof(Animator), globalParamAction.param), globalParamAction.value);
                         break;
                     }
                 }

--- a/com.vrcfury.vrcfury/Runtime/VF/Model/StateAction.cs
+++ b/com.vrcfury.vrcfury/Runtime/VF/Model/StateAction.cs
@@ -114,10 +114,10 @@ namespace VF.Model.StateAction {
         public float value;
         public ParamType paramType;
         public enum ParamType {
-        boolParam,
-        intParam,
-        floatParam
-    }
+            boolParam,
+            intParam,
+            floatParam
+        }
     }
 
 }

--- a/com.vrcfury.vrcfury/Runtime/VF/Model/StateAction.cs
+++ b/com.vrcfury.vrcfury/Runtime/VF/Model/StateAction.cs
@@ -108,4 +108,10 @@ namespace VF.Model.StateAction {
         public VRCPhysBone physBone;
     }
 
+    [Serializable]
+    public class SetGlobalParamAction: Action {
+        public string param;
+        public string value;
+    }
+
 }

--- a/com.vrcfury.vrcfury/Runtime/VF/Model/StateAction.cs
+++ b/com.vrcfury.vrcfury/Runtime/VF/Model/StateAction.cs
@@ -112,6 +112,12 @@ namespace VF.Model.StateAction {
     public class SetGlobalParamAction: Action {
         public string param;
         public string value;
+        public ParamType paramType;
+        public enum ParamType {
+        boolParam,
+        intParam,
+        floatParam
+    }
     }
 
 }

--- a/com.vrcfury.vrcfury/Runtime/VF/Model/StateAction.cs
+++ b/com.vrcfury.vrcfury/Runtime/VF/Model/StateAction.cs
@@ -111,7 +111,7 @@ namespace VF.Model.StateAction {
     [Serializable]
     public class SetGlobalParamAction: Action {
         public string param;
-        public string value;
+        public float value;
         public ParamType paramType;
         public enum ParamType {
         boolParam,


### PR DESCRIPTION
allows users to set global params in an action, param is stored as float curves and are converted to parameter drivers by CleanupEmptyLayersBuilder. Existing drive global parameter remains in tact, as there would be no way to set a param to false after toggle exited.