### PR TITLE
Don't fail build on missing materials in RestingStateBuilder

### DIFF
--- a/com.vrcfury.vrcfury/Editor/VF/Feature/RestingStateBuilder.cs
+++ b/com.vrcfury.vrcfury/Editor/VF/Feature/RestingStateBuilder.cs
@@ -134,6 +134,10 @@ namespace VF.Feature {
             var renderer = transform.GetComponent(binding.type) as Renderer;
             if (!renderer) return;
             renderer.sharedMaterials = renderer.sharedMaterials.Select(mat => {
+                if (mat == null) {
+                    Debug.Log($"The Material For Resting State Builder was null, offending renderer object: {renderer.gameObject.name}");
+                    return mat;
+                }
                 if (!mat.HasProperty(propName)) return mat;
                 mat = MutableManager.MakeMutable(mat);
                 mat.SetFloat(propName, val.GetFloat());


### PR DESCRIPTION
currently if a material slot is empty, but restingStateBuilder is trying to work on it the build just fails. 

With this change it will print a log in the console telling the user which mesh is the offending one and continues the build as if nothing happened.

Maybe this could be printed in some kind of GUI error panel after build at some point. (I would quite like that as a VRCF feature in general. Modular Avatar has something like that too)
```
The changes made in this contribution are free and unencumbered software
released into the public domain.

Anyone is free to copy, modify, publish, use, compile, sell, or
distribute this software, either in source code form or as a compiled
binary, for any purpose, commercial or non-commercial, and by any
means.

In jurisdictions that recognize copyright laws, the author or authors
of this software dedicate any and all copyright interest in the
software to the public domain. We make this dedication for the benefit
of the public at large and to the detriment of our heirs and
successors. We intend this dedication to be an overt act of
relinquishment in perpetuity of all present and future rights to this
software under copyright law.

THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND,
EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF
MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT.
IN NO EVENT SHALL THE AUTHORS BE LIABLE FOR ANY CLAIM, DAMAGES OR
OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE,
ARISING FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR
OTHER DEALINGS IN THE SOFTWARE.

For more information, please refer to <https://unlicense.org/>
```