### PR TITLE
detect if the menu item is the same and skip adding it

### DIFF
--- a/com.vrcfury.vrcfury/Editor/VF/Builder/Manager/MenuManager.cs
+++ b/com.vrcfury.vrcfury/Editor/VF/Builder/Manager/MenuManager.cs
@@ -276,6 +276,17 @@ namespace VF.Builder {
                         MergeMenu(prefix2.ToArray(), fromControl.subMenu, seen);
                     }
                 } else {
+                    //check if the exact same control exists, and if it does then just skip it
+                    bool exists = false;
+                    foreach (var toControl in to.controls)
+                    {
+                        //if they are similar by name, type, and parameter, then they are the same
+                        exists = toControl.name == fromControl.name
+                            && toControl.type == fromControl.type
+                            && toControl.parameter?.name == fromControl.parameter?.name;
+                        if (exists) break;
+                    }
+                    if (exists) continue;
                     to.controls.Add(CloneControl(fromControl));
                 }
             }


### PR DESCRIPTION
Actually resolves https://github.com/VRCFury/VRCFury/issues/15

Essentially checks if a menu item being added is exactly the same as one already there and will skip adding it to avoid duplicated menu items that refer to the exact same information