### PR TITLE
fix: make VRCF compatible with running preprocess hooks in play mode

### DIFF
--- a/com.vrcfury.vrcfury/Editor/VF/Builder/VRCFuryAssetContainer.cs
+++ b/com.vrcfury.vrcfury/Editor/VF/Builder/VRCFuryAssetContainer.cs
@@ -1,0 +1,16 @@
+﻿using UnityEditor;
+using UnityEngine;
+
+namespace VF.Builder
+{
+    /// <summary>
+    /// Unity 2019 has a bug in which creating assets with preview thumbnails early in Play Mode initialization causes
+    /// an editor crash (it also causes a lot of overhead otherwise). To workaround this bug, when saving assets in
+    /// Play Mode, we put them into this container asset, which does not have a thumbnail.
+    /// </summary>
+    [PreferBinarySerialization]
+    internal class VRCFuryAssetContainer : ScriptableObject
+    {
+        
+    }
+}

--- a/com.vrcfury.vrcfury/Editor/VF/Builder/VRCFuryAssetContainer.cs.meta
+++ b/com.vrcfury.vrcfury/Editor/VF/Builder/VRCFuryAssetContainer.cs.meta
@@ -1,0 +1,3 @@
+﻿fileFormatVersion: 2
+guid: 7ace936e7865406ebb5674bffe30814e
+timeCreated: 1705211907

--- a/com.vrcfury.vrcfury/Editor/VF/Builder/VRCFuryAssetDatabase.cs
+++ b/com.vrcfury.vrcfury/Editor/VF/Builder/VRCFuryAssetDatabase.cs
@@ -62,7 +62,21 @@ namespace VF.Builder {
                 ext = "asset";
             }
 
-            var fullPath = GetUniquePath(dir, filename, ext);
+            string fullPath;
+#if !UNITY_2022_1_OR_NEWER // this editor crash bug is apparently fixed in Unity 2022
+            if (EditorApplication.isPlaying && false)
+            {
+                // Workaround crash issues when saving assets in play mode
+                fullPath = GetUniquePath(dir, filename, "asset");
+                var container = ScriptableObject.CreateInstance<VRCFuryAssetContainer>();
+                AssetDatabase.CreateAsset(container, fullPath);
+                AssetDatabase.RemoveObjectFromAsset(obj);
+                AssetDatabase.AddObjectToAsset(obj, container);
+                return;
+            }
+#endif
+
+            fullPath = GetUniquePath(dir, filename, ext);
             // If object was already part of another asset, or was recently deleted, we MUST
             // call this first, or unity will throw an exception
             AssetDatabase.RemoveObjectFromAsset(obj);

--- a/com.vrcfury.vrcfury/Editor/VF/VrcHooks/PreuploadHook.cs
+++ b/com.vrcfury.vrcfury/Editor/VF/VrcHooks/PreuploadHook.cs
@@ -41,19 +41,6 @@ namespace VF.VrcHooks {
                     }
                 }
             }
-            
-            if (EditorApplication.isPlaying) {
-                vrcCloneObject?.Destroy();
-                original?.Destroy();
-                EditorUtility.DisplayDialog(
-                    "VRCFury",
-                    "Something asked VRCFury to build while play mode is still initializing. This is an av3emu bug and would cause unity to crash.\n\n" +
-                    "Consider using Gesture Manager instead, or uncheck 'Run Preprocess Avatar Hook' on the Av3 Emulator Control object.\n\n" +
-                    "The avatar object has been removed from play mode to avoid crashing.",
-                    "Ok"
-                );
-                return false;
-            }
 
             var builder = new VRCFuryBuilder();
             var vrcFuryStatus = builder.SafeRun(vrcCloneObject, original);


### PR DESCRIPTION
The crash issue that occurs in play mode transition is caused by creating
asset thumbnails early in play mode initialization. This change works around this
issue in the same manner as Modular Avatar, by putting those assets into a container
scriptable object that prevents thumbnail generation.

I've chosen to do this only for play mode at the moment, as I'm not sure if Fury has
made a deliberate design choice to store assets in separate standard-format files,
despite the additional overhead this entails.

## Why is this change needed?

For full compatibility with NDMF plugins, it's important to respect the correct order of hook execution. In particular,
certain optimization plugins (notably anatawa12's Avatar Optimizer) will break certain VRCFury features if they execute prior to 
VRCFury. NDMF splits its processing across multiple VRC build hooks at different priorities to accommodate this, but because 
VRCFury rejects using those hooks in play mode, this cannot be made to be fully compatible without this fix.
See #216 for some more details and information on next steps to further improve compatibility.