### PR TITLE
fix: disable NdmfFirstMenuItem for NDMF 1.3.0-rc.* or newer

### DIFF
--- a/com.vrcfury.vrcfury/Editor/VF/Menu/NdmfFirstMenuItem.cs
+++ b/com.vrcfury.vrcfury/Editor/VF/Menu/NdmfFirstMenuItem.cs
@@ -8,6 +8,9 @@ using Object = UnityEngine.Object;
 namespace VF.Menu {
     [InitializeOnLoad]
     public class NdmfFirstMenuItem {
+#if NDMF_HACK_NOT_REQUIRED
+        public static bool Get() => false;
+#else
         private const string EditorPref = "com.vrcfury.ndmfFirst";
 
         static NdmfFirstMenuItem() {
@@ -26,6 +29,7 @@ namespace VF.Menu {
             EditorPrefs.SetBool(EditorPref, !Get());
             UpdateMenu();
         }
+#endif
 
         private static Type GetAlreadyProcessedTagType() {
             return ReflectionUtils.GetTypeFromAnyAssembly("nadena.dev.ndmf.runtime.AlreadyProcessedTag");

--- a/com.vrcfury.vrcfury/Editor/VRCFury-Editor.asmdef
+++ b/com.vrcfury.vrcfury/Editor/VRCFury-Editor.asmdef
@@ -1,5 +1,6 @@
 {
     "name": "VRCFury-Editor",
+    "rootNamespace": "",
     "references": [
         "VRCFury",
         "VRCFury-Api",
@@ -37,6 +38,11 @@
             "name": "com.vrchat.base",
             "expression": "3.3.0",
             "define": "VRC_NEW_PUBLIC_SDK"
+        },
+        {
+            "name": "nadena.dev.ndmf",
+            "expression": "1.3.0-rc",
+            "define": "NDMF_HACK_NOT_REQUIRED"
         }
     ],
     "noEngineReferences": false


### PR DESCRIPTION
With NDMF 1.3.0, I intend to adjust the build hook order so that the NdmfFirstMenuItem
hack is not necessary. Further, executing all of NDMF in one go can cause compatibility
issues with optimization plugins, as noted in #216.

Once #219 goes in, and with NDMF 1.3.0, it is now possible to have good compatibility
between VRCF and NDMF/MA by using Av3 Emulator with preprocess hooks enabled. As such,
this hack is no longer necessary and should be disabled. To ease the transition, this
PR conditionally disables this hack when NDMF 1.3.0+ is installed, to allow for time
for folks to update. Eventually, this class should be deleted entirely.

Closes: #216
