### PR TITLE
Fix error with ACLS due to implicit truncation

### DIFF
--- a/com.vrcfury.vrcfury/SPS/sps_utils.cginc
+++ b/com.vrcfury.vrcfury/SPS/sps_utils.cginc
@@ -22,8 +22,8 @@ float3 sps_nearest_normal(float3 forward, float3 approximate) {
     return sps_normalize(cross(forward, cross(approximate, forward)));
 }
 
-float3 sps_toLocal(float3 v) { return mul(unity_WorldToObject, float4(v, 1)); }
-float3 sps_toWorld(float3 v) { return mul(unity_ObjectToWorld, float4(v, 1)); }
+float3 sps_toLocal(float3 v) { return mul(unity_WorldToObject, float4(v, 1)).xyz; }
+float3 sps_toWorld(float3 v) { return mul(unity_ObjectToWorld, float4(v, 1)).xyz; }
 // https://forum.unity.com/threads/point-light-in-v-f-shader.499717/#post-9052987
 float sps_attenToRange(float atten) { return 5.0 * (1.0 / sqrt(atten)); }
 


### PR DESCRIPTION
This fixes SPS's compatibility with ACLS due to an implicit truncation of float4 to float3. ACLS makes implicit truncations errors instead of warnings.