### PR TITLE
Fix parameter smoothing for negative values and survuve animator reload.

### DIFF
--- a/com.vrcfury.vrcfury/Editor/VF/Service/MathService.cs
+++ b/com.vrcfury.vrcfury/Editor/VF/Service/MathService.cs
@@ -238,23 +238,24 @@ namespace VF.Service {
         }
         
         /**
-         * When useDirect = true it only works on values > 0 !
+         * Only works on values > 0 !
          * Value MUST be defaulted to 0, or the copy will ADD to it
          */
-        public Motion MakeCopier(VFAFloatOrConst from, VFAFloat to, bool useDirect = true) {
+        public Motion MakeCopier(VFAFloatOrConst from, VFAFloat to) {
             if (from.param != null) {
-                if (useDirect) {
-                    var direct = MakeDirect($"{CleanName(to)} = {CleanName(from)}");
-                    direct.Add(from.param, MakeSetter(to, 1));
-                    return direct;
-                }
-                return Make1D($"{CleanName(to)} = {CleanName(from)}",
-                    from.param,
-                    (-1, MakeSetter(to, -1)),
-                    (1, MakeSetter(to, 1)));
+                var direct = MakeDirect($"{CleanName(to)} = {CleanName(from)}");
+                direct.Add(from.param, MakeSetter(to, 1));
+                return direct;
             } else {
                 return MakeSetter(to, from.constt);
             }
+        }
+
+        public Motion MakeCopierForNegativeValues(VFAFloatOrConst from, VFAFloat to) {
+            return Make1D($"{CleanName(to)} = {CleanName(from)}",
+                    from.param,
+                    (-1, MakeSetter(to, -1)),
+                    (1, MakeSetter(to, 1)));
         }
         
         public Motion MakeMaintainer(VFAFloat param) {

--- a/com.vrcfury.vrcfury/Editor/VF/Service/MathService.cs
+++ b/com.vrcfury.vrcfury/Editor/VF/Service/MathService.cs
@@ -238,14 +238,20 @@ namespace VF.Service {
         }
         
         /**
-         * Only works on values > 0 !
+         * When useDirect = true it only works on values > 0 !
          * Value MUST be defaulted to 0, or the copy will ADD to it
          */
-        public Motion MakeCopier(VFAFloatOrConst from, VFAFloat to) {
+        public Motion MakeCopier(VFAFloatOrConst from, VFAFloat to, bool useDirect = true) {
             if (from.param != null) {
-                var direct = MakeDirect($"{CleanName(to)} = {CleanName(from)}");
-                direct.Add(from.param, MakeSetter(to, 1));
-                return direct;
+                if (useDirect) {
+                    var direct = MakeDirect($"{CleanName(to)} = {CleanName(from)}");
+                    direct.Add(from.param, MakeSetter(to, 1));
+                    return direct;
+                }
+                return Make1D($"{CleanName(to)} = {CleanName(from)}",
+                    from.param,
+                    (-1, MakeSetter(to, -1)),
+                    (1, MakeSetter(to, 1)));
             } else {
                 return MakeSetter(to, from.constt);
             }

--- a/com.vrcfury.vrcfury/Editor/VF/Service/SmoothingService.cs
+++ b/com.vrcfury.vrcfury/Editor/VF/Service/SmoothingService.cs
@@ -72,10 +72,10 @@ namespace VF.Service {
 
         private Motion Smooth_(VFAFloat target, VFAFloat output, VFAFloat speedParam) {
             // Maintain tree - keeps the current value
-            var maintainTree = math.MakeCopier(output, output, useDirect: false);
+            var maintainTree = math.MakeCopierForNegativeValues(output, output);
 
             // Target tree - uses the target (input) value
-            var targetTree = math.MakeCopier(target, output, useDirect: false);
+            var targetTree = math.MakeCopierForNegativeValues(target, output);
 
             //The following two trees merge the update and the maintain tree together. The smoothParam controls 
             //how much from either tree should be applied during each tick

--- a/com.vrcfury.vrcfury/Editor/VF/Service/SmoothingService.cs
+++ b/com.vrcfury.vrcfury/Editor/VF/Service/SmoothingService.cs
@@ -72,10 +72,10 @@ namespace VF.Service {
 
         private Motion Smooth_(VFAFloat target, VFAFloat output, VFAFloat speedParam) {
             // Maintain tree - keeps the current value
-            var maintainTree = math.MakeMaintainer(output);
+            var maintainTree = math.MakeCopier(output, output, useDirect: false);
 
             // Target tree - uses the target (input) value
-            var targetTree = math.MakeCopier(target, output);
+            var targetTree = math.MakeCopier(target, output, useDirect: false);
 
             //The following two trees merge the update and the maintain tree together. The smoothParam controls 
             //how much from either tree should be applied during each tick


### PR DESCRIPTION
Currently, VRCFury uses a direct blend tree for a "copier", with a clip to set a parameter to 1 and a blend value. This relies on the base value of that parameter to be `0`, otherwise it will blend the value incorrectly.
When you enter a station in VRChat, the avatar's animator is partially reset. This resetting seems to cause the base value for the parameter to be set to the current value when the avatar's animator is reloaded.

The fix is to revert back to using a 1D blend tree for parameter smoothing but we should probably do this for all "copiers" where the blend value can be something other than 1. 

```
The changes made in this contribution are free and unencumbered software
released into the public domain.

Anyone is free to copy, modify, publish, use, compile, sell, or
distribute this software, either in source code form or as a compiled
binary, for any purpose, commercial or non-commercial, and by any
means.

In jurisdictions that recognize copyright laws, the author or authors
of this software dedicate any and all copyright interest in the
software to the public domain. We make this dedication for the benefit
of the public at large and to the detriment of our heirs and
successors. We intend this dedication to be an overt act of
relinquishment in perpetuity of all present and future rights to this
software under copyright law.

THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND,
EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF
MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT.
IN NO EVENT SHALL THE AUTHORS BE LIABLE FOR ANY CLAIM, DAMAGES OR
OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE,
ARISING FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR
OTHER DEALINGS IN THE SOFTWARE.

For more information, please refer to <https://unlicense.org>
```