### PR TITLE
Add 'zero-basis' weight entry for DBTs so that the total weight of ea…

### DIFF
--- a/com.vrcfury.vrcfury/Editor/VF/Service/MathService.cs
+++ b/com.vrcfury.vrcfury/Editor/VF/Service/MathService.cs
@@ -244,6 +244,7 @@ namespace VF.Service {
         public Motion MakeCopier(VFAFloatOrConst from, VFAFloat to) {
             if (from.param != null) {
                 var direct = MakeDirect($"{CleanName(to)} = {CleanName(from)}");
+                direct.Add(avatarManager.GetFx().One(), MakeSetter(to, 0));
                 direct.Add(from.param, MakeSetter(to, 1));
                 return direct;
             } else {


### PR DESCRIPTION
…ch clip is >=1

This fixes an issue with VRC stations where the default value of a parameter is reset to the current value.

Making sure that the total weight of DBT clips add up to or exceed 1 ignores the animator param default value.

```
The changes made in this contribution are free and unencumbered software
released into the public domain.

Anyone is free to copy, modify, publish, use, compile, sell, or
distribute this software, either in source code form or as a compiled
binary, for any purpose, commercial or non-commercial, and by any
means.

In jurisdictions that recognize copyright laws, the author or authors
of this software dedicate any and all copyright interest in the
software to the public domain. We make this dedication for the benefit
of the public at large and to the detriment of our heirs and
successors. We intend this dedication to be an overt act of
relinquishment in perpetuity of all present and future rights to this
software under copyright law.

THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND,
EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF
MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT.
IN NO EVENT SHALL THE AUTHORS BE LIABLE FOR ANY CLAIM, DAMAGES OR
OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE,
ARISING FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR
OTHER DEALINGS IN THE SOFTWARE.

For more information, please refer to <https://unlicense.org>
```