### PR TITLE
Merge Toggles

### DIFF
--- a/com.vrcfury.vrcfury/Editor/VF/Builder/Manager/MenuManager.cs
+++ b/com.vrcfury.vrcfury/Editor/VF/Builder/Manager/MenuManager.cs
@@ -224,6 +224,28 @@ namespace VF.Builder {
             control.icon = icon;
         }
 
+        public string GetMenuParam(string path, bool isFloat) {
+            var split = SplitPath(path);
+            if (split.Count == 0) split = new[] { "" };
+            var name = split[split.Count-1];
+            var submenu = GetSubmenu(Slice(split, split.Count-1));
+            foreach (var control in submenu.controls) {
+                if (control.name == name) {
+                    switch(control.type) 
+                    {
+                        case VRCExpressionsMenu.Control.ControlType.Button:
+                        case VRCExpressionsMenu.Control.ControlType.Toggle:
+                            if (!isFloat && control.value == 1) return control.parameter.name;
+                            break;
+                        case VRCExpressionsMenu.Control.ControlType.RadialPuppet:
+                            if (isFloat) return control.parameter.name;
+                            break;
+                    }
+                }
+            }
+            return null;
+        }
+
         private VRCExpressionsMenu CreateNewMenu(IList<string> path) {
             var cleanPath = path.Select(CleanTitleForFilename);
             var newMenu = ScriptableObject.CreateInstance<VRCExpressionsMenu>();


### PR DESCRIPTION
Toggles with menu paths that already exist will have their behaviors merged together, the original toggle is structurally unaffected

Use Cases:
1. Adding additional functionality to a prefabed toggle, such as adding a hand pose or an exclusive tag
2. Having unified toggles for several assets, allows for increased modularity if you want to have one toggle affect multiple assets without having to worry about making one master toggle for them all