### PR TITLE
Partial fix for FixMasksBuilder conflicting with AnimatorLayerControlOffsetBuilder

### DIFF
--- a/com.vrcfury.vrcfury/Editor/VF/Feature/AnimatorLayerControlOffsetBuilder.cs
+++ b/com.vrcfury.vrcfury/Editor/VF/Feature/AnimatorLayerControlOffsetBuilder.cs
@@ -104,6 +104,20 @@ namespace VF.Feature {
             mapping.Put(control, targetSm);
         }
 
+        public void Update(AnimatorStateMachine oldTargetSm, AnimatorStateMachine newTargetSm) {
+            // Replace all instances of oldTargetSm with newTargetSm
+            
+            foreach (var key in mapping.GetKeys()) {
+                var targetList = mapping.Get(key);
+
+                for (int i = 0; i < targetList.Count; i++) {
+                    if (targetList[i] == oldTargetSm) {
+                        targetList[i] = newTargetSm;
+                    }
+                }
+            }
+        }
+
         public bool IsLayerTargeted(AnimatorStateMachine sm) {
             return mapping.ContainsValue(sm);
         }

--- a/com.vrcfury.vrcfury/Editor/VF/Feature/FixMasksBuilder.cs
+++ b/com.vrcfury.vrcfury/Editor/VF/Feature/FixMasksBuilder.cs
@@ -16,6 +16,8 @@ namespace VF.Feature {
     [VFService]
     public class FixMasksBuilder : FeatureBuilder {
 
+        [VFAutowired] private readonly AnimatorLayerControlOffsetBuilder animatorLayerControlManager;
+
         private enum PropType {
             Muscle,
             Aap,
@@ -87,7 +89,13 @@ namespace VF.Feature {
                     }
                     // Remove behaviours from the fx copy
                     AnimatorIterator.ForEachBehaviourRW(vfCopy, (behaviour, add) => false);
+
+                    // TODO: How to handle AnimatorLayerControlOffsetBuilder in this case?
+                    // Should the new controller target both layers in the same way it targeted the original layer?
                 } else {
+                    // Update AnimatorLayerControlOffsetBuilder's references to the replacement state machine.
+                    animatorLayerControlManager.Update(layer.stateMachine, copyLayer.stateMachine);
+
                     // Move everything to FX and just delete the original
                     layer.Remove();
                 }


### PR DESCRIPTION
Unfortunately I'm not confident enough in my understanding of FixMasksBuilder to handle the case where the layer is copied + modified, but for the case where FixMasksBuilder deletes/remakes the layers it moves into the FX controller it effectively invalidates the references used by AnimatorLayerControlOffsetBuilder to figure out where those layers went.

This fix simply swaps out the references to the removed state machines with references to the newly created ones when this "move" is performed.  No worries if there's a better way to address this issue, it seemed simple enough that I figured I'd take a crack at fixing what I could instead of just filing a bug report.  Hope it's helpful!