### PR TITLE
add explicit blendshape Toggle off-state

### DIFF
--- a/com.vrcfury.vrcfury/Editor/VF/Feature/ToggleBuilder.cs
+++ b/com.vrcfury.vrcfury/Editor/VF/Feature/ToggleBuilder.cs
@@ -138,6 +138,17 @@ public class ToggleBuilder : FeatureBuilder<Toggle> {
         var layer = fx.NewLayer(layerName);
         var off = layer.NewState("Off");
 
+        var blendShapeOffState = new State {
+            actions = model.state.actions
+                .OfType<BlendShapeAction>()
+                .Where(b => b.hasBlendShapeValueOff)
+                .Select(b => b.CloneAsOffAction() as Model.StateAction.Action)
+                .ToList()
+        };
+        if (blendShapeOffState.actions.Count > 0) {
+            off = off.WithAnimation(actionClipService.LoadState("Off", blendShapeOffState));
+        }
+
         if (model.separateLocal) {
             var isLocal = fx.IsLocal().IsTrue();
             Apply(fx, layer, off, onCase.And(isLocal.Not()), weight, defaultOn, "On Remote", model.state, model.transitionStateIn, model.transitionStateOut, model.transitionTimeIn, model.transitionTimeOut);

--- a/com.vrcfury.vrcfury/Editor/VF/Inspector/VRCFuryActionEditor.cs
+++ b/com.vrcfury.vrcfury/Editor/VF/Inspector/VRCFuryActionEditor.cs
@@ -314,6 +314,30 @@ public class VRCFuryActionDrawer : PropertyDrawer {
                 });
                 content.Add(valueField);
 
+                var valueOffProp = prop.FindPropertyRelative("blendShapeValueOff");
+                var valueOffField = VRCFuryEditorUtils.Prop(valueOffProp, "Off Value");
+                valueOffField.RegisterCallback<ChangeEvent<float>>(e => {
+                    if (e.newValue < 0) {
+                        valueOffProp.floatValue = 0;
+                        ApplyWithoutUndo();
+                    }
+                    if (e.newValue > 100) {
+                        valueOffProp.floatValue = 100;
+                        ApplyWithoutUndo();
+                    }
+                });
+
+                var hasBlendShapeValueOffProp = prop.FindPropertyRelative("hasBlendShapeValueOff");
+                var hasBlendShapeValueOffField = VRCFuryEditorUtils.Prop(hasBlendShapeValueOffProp, "Override Value while Off");
+                hasBlendShapeValueOffField.RegisterCallback<ChangeEvent<bool>>(e => {
+                    hasBlendShapeValueOffProp.boolValue = e.newValue;
+                    ApplyWithoutUndo();
+                    valueOffField.SetVisible(e.newValue);
+                });
+
+                content.Add(hasBlendShapeValueOffField);
+                content.Add(valueOffField);
+
                 void SelectButtonPress() {
                     var window = new VrcfSearchWindow("Blendshapes");
                     var allRenderers = allRenderersProp.boolValue;

--- a/com.vrcfury.vrcfury/Editor/VF/Service/ActionClipService.cs
+++ b/com.vrcfury.vrcfury/Editor/VF/Service/ActionClipService.cs
@@ -201,13 +201,16 @@ namespace VF.Service {
                             if (!blendShape.allRenderers && blendShape.renderer != skin) continue;
                             if (!skin.HasBlendshape(blendShape.blendShape)) continue;
                             foundOne = true;
-                            //var defValue = skin.GetBlendShapeWeight(blendShapeIndex);
                             var binding = EditorCurveBinding.FloatCurve(
                                 clipBuilder.GetPath(skin.owner()),
                                 typeof(SkinnedMeshRenderer),
                                 "blendShape." + blendShape.blendShape
                             );
                             onClip.SetCurve(binding, blendShape.blendShapeValue);
+                            if (blendShape.hasBlendShapeValueOff)
+                            {
+                                offClip.SetCurve(binding, blendShape.blendShapeValueOff);
+                            }
                         }
                         if (!foundOne) {
                             Debug.LogWarning("BlendShape not found: " + blendShape.blendShape);

--- a/com.vrcfury.vrcfury/Runtime/VF/Model/StateAction.cs
+++ b/com.vrcfury.vrcfury/Runtime/VF/Model/StateAction.cs
@@ -53,18 +53,6 @@ namespace VF.Model.StateAction {
         public bool allRenderers = true;
         public bool hasBlendShapeValueOff;
         public float blendShapeValueOff;
-
-        public BlendShapeAction CloneAsOffAction() {
-            Debug.Assert(hasBlendShapeValueOff);
-            return new BlendShapeAction {
-                blendShape = blendShape,
-                blendShapeValue = blendShapeValueOff,
-                renderer = renderer,
-                allRenderers = allRenderers,
-                desktopActive = desktopActive,
-                androidActive = androidActive,
-            };
-        }
     }
     
     [Serializable]

--- a/com.vrcfury.vrcfury/Runtime/VF/Model/StateAction.cs
+++ b/com.vrcfury.vrcfury/Runtime/VF/Model/StateAction.cs
@@ -51,6 +51,20 @@ namespace VF.Model.StateAction {
         public float blendShapeValue = 100;
         public Renderer renderer;
         public bool allRenderers = true;
+        public bool hasBlendShapeValueOff;
+        public float blendShapeValueOff;
+
+        public BlendShapeAction CloneAsOffAction() {
+            Debug.Assert(hasBlendShapeValueOff);
+            return new BlendShapeAction {
+                blendShape = blendShape,
+                blendShapeValue = blendShapeValueOff,
+                renderer = renderer,
+                allRenderers = allRenderers,
+                desktopActive = desktopActive,
+                androidActive = androidActive,
+            };
+        }
     }
     
     [Serializable]


### PR DESCRIPTION
This is something I made for my personal avatar use-case, if this isn't something upstream wants to support that's fine too.

My user story is that I want to set blendshapes to 100 on the mesh directly, so they look correct/enabled when someone has my animators turned off, but still animate the blendshape via a toggle from 0 to 100. The current default behaviour, where it grabs the mesh state at upload time as the base, isn't quite ideal for me.

This might break other things since it changes things on the `ActionClipService`, but so far it's been working great for me?