### PR TITLE
Optimize Parameters

### DIFF
--- a/com.vrcfury.vrcfury/Editor/VF/Builder/Manager/ControllerManager.cs
+++ b/com.vrcfury.vrcfury/Editor/VF/Builder/Manager/ControllerManager.cs
@@ -194,6 +194,10 @@ namespace VF.Builder {
             return ctrl.NewFloat(name, def);
         }
 
+        public void UnsyncParam(string name){
+            GetParamManager().UnsyncSyncedParam(name);
+        }
+
         private readonly int randomPrefix = (new System.Random()).Next(100_000_000, 999_999_999);
 
         public VFABool True() {

--- a/com.vrcfury.vrcfury/Editor/VF/Builder/Manager/ParamManager.cs
+++ b/com.vrcfury.vrcfury/Editor/VF/Builder/Manager/ParamManager.cs
@@ -1,6 +1,7 @@
 using System;
 using System.Collections.Generic;
 using System.Linq;
+using System.Reflection;
 using VF.Inspector;
 using VRC.SDK3.Avatars.ScriptableObjects;
 
@@ -8,6 +9,9 @@ namespace VF.Builder {
 
     public class ParamManager {
         private readonly VRCExpressionParameters syncedParams;
+
+        private static readonly FieldInfo networkSyncedField =
+            typeof(VRCExpressionParameters.Parameter).GetField("networkSynced");
 
         public ParamManager(VRCExpressionParameters syncedParams) {
             this.syncedParams = syncedParams;
@@ -26,6 +30,21 @@ namespace VF.Builder {
             var syncedParamsList = new List<VRCExpressionParameters.Parameter>(syncedParams.parameters);
             syncedParamsList.Add(param);
             syncedParams.parameters = syncedParamsList.ToArray();
+            VRCFuryEditorUtils.MarkDirty(syncedParams);
+        }
+
+        public void UnsyncSyncedParam(string name) {
+            var exists = GetParam(name);
+            if (exists == null) {
+                return;
+            }
+            for (int i = 0; i < syncedParams.parameters.Length; i++)
+            {
+                if (syncedParams.parameters[i] == exists) {
+                    if (networkSyncedField != null) networkSyncedField.SetValue(syncedParams.parameters[i], false);
+                    break;
+                }
+            }
             VRCFuryEditorUtils.MarkDirty(syncedParams);
         }
 

--- a/com.vrcfury.vrcfury/Editor/VF/Feature/Base/FeatureOrder.cs
+++ b/com.vrcfury.vrcfury/Editor/VF/Feature/Base/FeatureOrder.cs
@@ -101,6 +101,7 @@ namespace VF.Feature.Base {
 
         // Finalize Parameters
         FixBadParameters,
+        OptimizeParams,
         FinalizeParams,
 
         MarkThingsAsDirtyJustInCase,

--- a/com.vrcfury.vrcfury/Editor/VF/Feature/OptimizeParamsBuilder.cs
+++ b/com.vrcfury.vrcfury/Editor/VF/Feature/OptimizeParamsBuilder.cs
@@ -110,23 +110,22 @@ namespace VF.Feature {
             paramSlotsAvailable--; // index int
             totalCost+=8; // index int
 
-            var setCount = 0;
+            var setCount = Math.Min(paramSlotsAvailable / paramsPerSet, (maxBits - totalCost) / bitsPerSet);
 
-            if (paramSlotsAvailable >= paramsPerSet) {
-                setCount = Math.Min(paramSlotsAvailable / paramsPerSet, (maxBits - totalCost) / bitsPerSet);
-            } else if (paramSlotsAvailable < minSlotsNeeded) {
-                 excService.ThrowIfActuallyUploading(new SneakyException(
-                    $"Your avatar is using too many synced and unsynced expression parameters and they can't be further optimized!"
-                    + " A bug in vrchat causes this to unexpectedly throw away some of your parameters.\n\n" +
-                    "https://feedback.vrchat.com/avatar-30/p/1332-bug-vrcexpressionparameters-fail-to-load-correctly-with-more-than-256-param"));
-                 return;
-            } else {
-                setCount = 1;
-                intsPerSet = 1;
-                floatsPerSet = 1;
-                boolsPerSet = paramSlotsAvailable - 2;
+            if (setCount == 0) {
+                if (paramSlotsAvailable < minSlotsNeeded) {
+                     excService.ThrowIfActuallyUploading(new SneakyException(
+                        $"Your avatar is using too many synced and unsynced expression parameters and they can't be further optimized!"
+                        + " A bug in vrchat causes this to unexpectedly throw away some of your parameters.\n\n" +
+                        "https://feedback.vrchat.com/avatar-30/p/1332-bug-vrcexpressionparameters-fail-to-load-correctly-with-more-than-256-param"));
+                     return;
+                } else {
+                    setCount = 1;
+                    intsPerSet = ints.Count() > 0 ? 1 : 0;
+                    floatsPerSet = floats.Count() > 0 ? 1 : 0;
+                    boolsPerSet = paramSlotsAvailable - intsPerSet - floatsPerSet;
+                }
             }
-
 
             Dictionary<string, (int, int)> paramMap = new Dictionary<string, (int, int)>();
 

--- a/com.vrcfury.vrcfury/Editor/VF/Feature/OptimizeParamsBuilder.cs
+++ b/com.vrcfury.vrcfury/Editor/VF/Feature/OptimizeParamsBuilder.cs
@@ -5,18 +5,14 @@ using System.Reflection;
 using UnityEditor;
 using UnityEngine;
 using UnityEngine.UIElements;
-using VF.Builder;
 using VF.Builder.Exceptions;
-using VF.Component;
 using VF.Feature.Base;
 using VF.Injector;
 using VF.Inspector;
 using VF.Model.Feature;
 using VF.Service;
 using VF.Utils.Controller;
-using VRC.Dynamics;
 using VRC.SDK3.Avatars.ScriptableObjects;
-using VRC.SDK3.Dynamics.Contact.Components;
 
 namespace VF.Feature {
     public class OptimizeParamsBuilder : FeatureBuilder<OptimizeParams> {

--- a/com.vrcfury.vrcfury/Editor/VF/Feature/OptimizeParamsBuilder.cs
+++ b/com.vrcfury.vrcfury/Editor/VF/Feature/OptimizeParamsBuilder.cs
@@ -1,0 +1,239 @@
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Reflection;
+using UnityEditor;
+using UnityEngine;
+using UnityEngine.UIElements;
+using VF.Builder;
+using VF.Builder.Exceptions;
+using VF.Component;
+using VF.Feature.Base;
+using VF.Injector;
+using VF.Inspector;
+using VF.Model.Feature;
+using VF.Service;
+using VF.Utils.Controller;
+using VRC.Dynamics;
+using VRC.SDK3.Avatars.ScriptableObjects;
+using VRC.SDK3.Dynamics.Contact.Components;
+
+namespace VF.Feature {
+    public class OptimizeParamsBuilder : FeatureBuilder<OptimizeParams> {
+        [VFAutowired] private readonly ExceptionService excService;
+
+        private static readonly FieldInfo networkSyncedField =
+            typeof(VRCExpressionParameters.Parameter).GetField("networkSynced");
+
+        [FeatureBuilderAction(FeatureOrder.OptimizeParams)]
+        public void Apply() {
+            if (networkSyncedField == null) {
+                // can't optimize
+                Debug.Log("Network Sync Field not available, Param Optimizer unable to run. Please update VRCSDK");
+                return;
+            }
+            var p = manager.GetParams();
+            var maxBits = VRCExpressionParameters.MAX_PARAMETER_COST;
+            if (maxBits > 9999) {
+                // Some versions of the VRChat SDK have a broken value for this
+                maxBits = 256;
+            }
+            var totalCost = p.GetRaw().CalcTotalCost();
+            if (totalCost <= maxBits) {
+                // nothing to optimize
+                return;
+            }
+
+            List<string> bools = new List<string>();
+            List<string> floats = new List<string>();
+            List<string> ints = new List<string>();
+
+            foreach (var param in p.GetRaw().parameters)
+            {
+                if (!param.networkSynced) continue;
+
+                switch(param.valueType) {
+                    case VRCExpressionParameters.ValueType.Bool:
+                        bools.Add(param.name);
+                        break;
+                    case VRCExpressionParameters.ValueType.Float:
+                        floats.Add(param.name);
+                        break;
+                    case VRCExpressionParameters.ValueType.Int:
+                        ints.Add(param.name);
+                        break;
+                }
+            }
+
+            var optimizeBool = false;
+            var optimizeFloat = false;
+            var optimizeInt = false;
+
+            int optimizedTypes;
+
+            if (totalCost + 16 - bools.Count() <= maxBits) {
+                optimizeBool = true;
+                ints.Clear();
+                floats.Clear();
+                optimizedTypes = 1;
+                Debug.Log("Optimizing Bools");
+            } else if (totalCost + 24 - ints.Count()*8 - bools.Count()*8 <= maxBits) {
+                optimizeInt = true;
+                optimizeBool = true;
+                floats.Clear();
+                optimizedTypes = 2;
+                Debug.Log("Optimizing Bools and Ints");
+            } else {
+                optimizeBool = true;
+                optimizeInt = true;
+                optimizeFloat = true;
+                optimizedTypes = 3;
+                Debug.Log("Optimizing Bools, Floats, and Ints");
+            }
+
+            var paramsPerSet = 0;
+            var bitsPerSet = optimizedTypes * 8;
+
+            if (optimizeBool) paramsPerSet += 8;
+            if (optimizeInt) paramsPerSet++;
+            if (optimizeFloat) paramsPerSet++;
+
+            totalCost -= bools.Count();
+            totalCost -= ints.Count()*8;
+            totalCost -= floats.Count()*8;
+
+            var paramSlotsAvailable = 256 - p.GetRaw().parameters.Length;
+
+            paramSlotsAvailable--; // index int
+            totalCost+=8; // index int
+
+            var setCount = 0;
+            var boolsPerSet = 8;
+
+            if (paramSlotsAvailable >= paramsPerSet) {
+                setCount = Math.Min(paramSlotsAvailable / paramsPerSet, (maxBits - totalCost) / bitsPerSet);
+            } else if (paramSlotsAvailable < optimizedTypes) {
+                 excService.ThrowIfActuallyUploading(new SneakyException(
+                    $"Your avatar is using too many synced and unsynced expression parameters and they can't be further optimized!"
+                    + " A bug in vrchat causes this to unexpectedly throw away some of your parameters.\n\n" +
+                    "https://feedback.vrchat.com/avatar-30/p/1332-bug-vrcexpressionparameters-fail-to-load-correctly-with-more-than-256-param"));
+            } else {
+                setCount = 1;
+                boolsPerSet = paramSlotsAvailable - 2;
+            }
+
+
+            Dictionary<string, (int, int)> paramMap = new Dictionary<string, (int, int)>();
+
+            var index = 0;
+            foreach (var param in bools) {
+                paramMap[param] = (index / (boolsPerSet * setCount), index % (boolsPerSet * setCount));
+                index++;
+            }
+
+            index = 0;
+            foreach(var param in floats) {
+                paramMap[param] = (index / setCount, index % setCount);
+                index++;
+            }
+
+            index = 0;
+            foreach(var param in ints) {
+                paramMap[param] = (index / setCount, index % setCount);
+                index++;
+            }
+
+            var syncIndex = fx.NewInt("SYNC", synced: true, def: -1);
+            List<VFAParam> syncBools = new List<VFAParam>();
+            List<VFAParam> syncInts = new List<VFAParam>();
+            List<VFAParam> syncFloats = new List<VFAParam>();
+
+            for (var i = 0; i < setCount; i++) {
+                if (optimizeBool) {
+                    for (var j = 0; j < boolsPerSet; j++) {
+                        syncBools.Add(fx.NewBool("SYNC_BOOL_" + (i * boolsPerSet + j), synced: true));
+                    }
+                }
+
+                if (optimizeFloat) syncFloats.Add(fx.NewFloat("SYNC_FLOAT_" + i, synced: true));
+                if (optimizeInt) syncInts.Add(fx.NewInt("SYNC_INT_" + i, synced: true));
+            }
+
+            var maxIndex = new [] { bools.Count() / setCount / boolsPerSet, ints.Count() / setCount, floats.Count() / setCount }.Max() + 1;
+
+            var localLayer = fx.NewLayer("Optimized Sync Local");
+            var remoteLayer = fx.NewLayer("Optimized Sync Remote");
+
+            List<VFState> localStates = new List<VFState>();
+            List<VFState> remoteStates = new List<VFState>();
+
+            var localStart = localLayer.NewState("Start");
+            var remoteStart = remoteLayer.NewState("Start");
+
+
+            VFState lastLocal = null;
+
+            for (var i = 0; i < maxIndex; i++) {
+                var localState = localLayer.NewState("Sync " + i).Drives(syncIndex.Name(), i);
+                if (lastLocal != null) {
+                    lastLocal.TransitionsTo(localState).When(fx.True().IsTrue());
+                }
+                lastLocal = localState;
+                localStates.Add(localState);
+
+                var remoteState = remoteLayer.NewState("Sync " + i);
+                remoteState.TransitionsFromAny().When(syncIndex.IsEqualTo(i).And(fx.IsLocal().IsFalse()));
+                remoteStates.Add(remoteState);
+            }
+
+            localStart.TransitionsTo(localStates[0]).When(fx.IsLocal().IsTrue());
+            lastLocal.TransitionsTo(localStates[0]).When(fx.True().IsTrue());
+            
+            foreach (var param in bools) {
+                fx.UnsyncParam(param);
+                var (indexVal, offsetVal) = paramMap[param];
+                localStates[indexVal].DrivesCopy(syncBools[offsetVal].Name(), param, false);
+                remoteStates[indexVal].DrivesCopy(param, syncBools[offsetVal].Name(), false);
+            }
+
+            foreach (var param in ints) {
+                fx.UnsyncParam(param);
+                var (indexVal, offsetVal) = paramMap[param];
+                localStates[indexVal].DrivesCopy(syncInts[offsetVal].Name(), param, false);
+                remoteStates[indexVal].DrivesCopy(param, syncInts[offsetVal].Name(), false);
+            }
+
+            foreach (var param in floats) {
+                fx.UnsyncParam(param);
+                var (indexVal, offsetVal) = paramMap[param];
+                localStates[indexVal].DrivesCopy(syncFloats[offsetVal].Name(), param, false);
+                remoteStates[indexVal].DrivesCopy(param, syncFloats[offsetVal].Name(), false);
+            }
+        }
+
+        public override string GetEditorTitle() {
+            return "Parameter Optimizer";
+        }
+
+        public override bool OnlyOneAllowed() {
+            return true;
+        }
+
+        public override bool AvailableOnRootOnly() {
+            return true;
+        }
+
+        public override VisualElement CreateEditor(SerializedProperty prop) {
+            var content = new VisualElement();
+            content.Add(VRCFuryEditorUtils.Info(
+                "This feature will attempt to reduce the amount of synced params " +
+                "used by your avatar by syncing them in a round robin method. " +
+                "It will attempt to optimize bools, then ints, then floats in that order. " +
+                "This may cause parameters to sync slightly slower in some cases, but " +
+                "allows for more params than would usually be allowed on an avatar. " +
+                "Due to some of VRC's limitations, it still may not be possible to optimize " +
+                "the avatar in certain configurations."));
+            return content;
+        }
+    }
+}

--- a/com.vrcfury.vrcfury/Editor/VF/Feature/OptimizeParamsBuilder.cs
+++ b/com.vrcfury.vrcfury/Editor/VF/Feature/OptimizeParamsBuilder.cs
@@ -72,11 +72,14 @@ namespace VF.Feature {
                 Debug.Log("Optimizing Bools, Floats, and Ints");
             }
 
-            var minValue = Math.Max(1, new [] {bools.Count(), ints.Count(), floats.Count() }.Min());
+            if (ints.Count() == 1) ints.Clear(); // won't do any good anyway
+            if (floats.Count() == 1) floats.Clear(); // won't do any good anyway
 
-            var boolsPerSet = bools.Count() / minValue;
-            var intsPerSet = ints.Count() / minValue;
-            var floatsPerSet = floats.Count() / minValue;
+            var minValue = new [] {bools.Count(), ints.Count(), floats.Count() }.Where(x => x != 0).Min();
+
+            var boolsPerSet = (int) Math.Round((float) bools.Count() / minValue);
+            var intsPerSet = (int) Math.Round((float) ints.Count() / minValue);
+            var floatsPerSet = (int) Math.Round((float) floats.Count() / minValue);
 
             var paramsPerSet = 0;
             var bitsPerSet = 0;

--- a/com.vrcfury.vrcfury/Editor/VF/Feature/OptimizeParamsBuilder.cs
+++ b/com.vrcfury.vrcfury/Editor/VF/Feature/OptimizeParamsBuilder.cs
@@ -119,6 +119,7 @@ namespace VF.Feature {
                     $"Your avatar is using too many synced and unsynced expression parameters and they can't be further optimized!"
                     + " A bug in vrchat causes this to unexpectedly throw away some of your parameters.\n\n" +
                     "https://feedback.vrchat.com/avatar-30/p/1332-bug-vrcexpressionparameters-fail-to-load-correctly-with-more-than-256-param"));
+                 return;
             } else {
                 setCount = 1;
                 intsPerSet = 1;
@@ -172,7 +173,7 @@ namespace VF.Feature {
                 }
             }
 
-            var maxIndex = new [] { bools.Count() / (boolsPerSet * setCount), ints.Count() / (intsPerSet * setCount), floats.Count() / (floatsPerSet * setCount) }.Max() + 1;
+            var maxIndex = new [] { bools.Count() / (Math.Max(boolsPerSet, 1) * setCount), ints.Count() / (Math.Max(intsPerSet, 1) * setCount), floats.Count() / (Math.Max(floatsPerSet, 1) * setCount) }.Max() + 1;
 
             var localLayer = fx.NewLayer("Optimized Sync Local");
             var remoteLayer = fx.NewLayer("Optimized Sync Remote");

--- a/com.vrcfury.vrcfury/Editor/VF/Feature/OptimizeParamsBuilder.cs
+++ b/com.vrcfury.vrcfury/Editor/VF/Feature/OptimizeParamsBuilder.cs
@@ -123,7 +123,7 @@ namespace VF.Feature {
                     setCount = 1;
                     intsPerSet = ints.Count() > 0 ? 1 : 0;
                     floatsPerSet = floats.Count() > 0 ? 1 : 0;
-                    boolsPerSet = Math.Min(paramSlotsAvailable - intsPerSet - floatsPerSet, maxBits - totalCost - intsPerSet - floatsPerSet);
+                    boolsPerSet = Math.Min(paramSlotsAvailable - intsPerSet - floatsPerSet, maxBits - totalCost -  8*intsPerSet - 8*floatsPerSet);
                 }
             }
 

--- a/com.vrcfury.vrcfury/Editor/VF/Feature/OptimizeParamsBuilder.cs.meta
+++ b/com.vrcfury.vrcfury/Editor/VF/Feature/OptimizeParamsBuilder.cs.meta
@@ -1,0 +1,11 @@
+fileFormatVersion: 2
+guid: b0588956083366247adde399f55693c4
+MonoImporter:
+  externalObjects: {}
+  serializedVersion: 2
+  defaultReferences: []
+  executionOrder: 0
+  icon: {instanceID: 0}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/com.vrcfury.vrcfury/Editor/VF/Utils/Controller/VFState.cs
+++ b/com.vrcfury.vrcfury/Editor/VF/Utils/Controller/VFState.cs
@@ -100,13 +100,18 @@ namespace VF.Utils.Controller {
             p.value = delta;
             return this;
         }
-        public VFState DrivesCopy(VFAInteger param, VFAInteger source) {
-            var driver = GetDriver(true);
+        public VFState DrivesCopy(VFAParam param, VFAParam source, bool local = true) {
+            DrivesCopy(param.Name(), source.Name());
+            return this;
+        }
+
+        public VFState DrivesCopy(string param, string source, bool local = true) {
+            var driver = GetDriver(local);
             var p = new VRC_AvatarParameterDriver.Parameter();
-            p.name = param.Name();
+            p.name = param;
             var sourceField = p.GetType().GetField("source");
             if (sourceField == null) throw new VRCFBuilderException("VRCFury feature failed to build because VRCSDK is outdated");
-            sourceField.SetValue(p, source.Name());
+            sourceField.SetValue(p, source);
             // We cast rather than use Copy directly so it doesn't fail to compile on old VRCSDK
             p.type = (VRC_AvatarParameterDriver.ChangeType)3; //VRC_AvatarParameterDriver.ChangeType.Copy;
             driver.parameters.Add(p);

--- a/com.vrcfury.vrcfury/Runtime/VF/Model/Feature.cs
+++ b/com.vrcfury.vrcfury/Runtime/VF/Model/Feature.cs
@@ -1014,4 +1014,8 @@ namespace VF.Model.Feature {
     public class SecurityRestricted : NewFeatureModel {
     }
 
+    [Serializable]
+    public class OptimizeParams : NewFeatureModel {
+    }
+
 }


### PR DESCRIPTION
Added feature that will attempt to optimize synced parameters using a round robin method.
Based partially on https://github.com/VRCFury/VRCFury/pull/238, this feature will attempt to optimize bools, then ints, then floats, stopping once the avatar is under the 256 limit. The builder respects both the bit and param count limits. The reason for this order is so that the fine control when manually setting floats is not lost if possible. Tested to make sure that late joiners see correct toggles as well.