### PR TITLE
Add "Build an Editor Test Copy" to GameObject Context Menu.

### DIFF
--- a/com.vrcfury.vrcfury/Editor/VF/Menu/MenuItems.cs
+++ b/com.vrcfury.vrcfury/Editor/VF/Menu/MenuItems.cs
@@ -95,10 +95,12 @@ namespace VF.Menu {
             return MenuUtils.GetSelectedAvatar() != null;
         }
 
+        [MenuItem("GameObject/VRCFury/Build an Editor Test Copy", priority = 42)]
         [MenuItem(testCopy, priority = testCopyPriority)]
         private static void RunForceRun() {
             VRCFuryTestCopyMenuItem.RunBuildTestCopy();
         }
+        [MenuItem("GameObject/VRCFury/Build an Editor Test Copy", true)]
         [MenuItem(testCopy, true)]
         private static bool CheckForceRun() {
             return VRCFuryTestCopyMenuItem.CheckBuildTestCopy();


### PR DESCRIPTION
Adds a context-aware "Build an Editor Test Copy" when right-clicking an avatar in the Hierarchy.
Using the same approach that was used for Sockets and Plugs.

Would be neat to have.