### PR TITLE
Extend Toggle Public API

### DIFF
--- a/com.vrcfury.vrcfury/PublicApi/Actions/FuryActionSet.cs
+++ b/com.vrcfury.vrcfury/PublicApi/Actions/FuryActionSet.cs
@@ -40,5 +40,12 @@ namespace com.vrcfury.api.Actions {
             a.blendShapeValue = value;
             s.actions.Add(a);
         }
+
+        public void AddSetFXFloat(string name, float value) {
+            var a = new FxFloatAction();
+            a.name = name;
+            a.value = value;
+            s.actions.Add(a);
+        }
     }
 }

--- a/com.vrcfury.vrcfury/PublicApi/Components/FuryToggle.cs
+++ b/com.vrcfury.vrcfury/PublicApi/Components/FuryToggle.cs
@@ -27,6 +27,10 @@ namespace com.vrcfury.api.Components {
         public void SetDefaultOn() {
             c.defaultOn = true;
         }
+
+        public void SetSaved() {
+            c.saved = true;
+        }
         
         public void SetExclusiveOffState() {
             c.exclusiveOffState = true;
@@ -36,6 +40,11 @@ namespace com.vrcfury.api.Components {
             c.enableExclusiveTag = true;
             if (!string.IsNullOrEmpty(c.exclusiveTag)) c.exclusiveTag += ",";
             c.exclusiveTag += tag;
+        }
+
+        public void SetGlobalParameter(string globalParameter) {
+            c.useGlobalParam = true;
+            c.globalParam = globalParameter;
         }
 
         public FuryActionSet GetActions() {


### PR DESCRIPTION
Extends `FuryToggle` with `SetSaved` and `SetGlobalParameter`, and `FuryActionSet` with `AddSetFXFloat`

```
The changes made in this contribution are free and unencumbered software
released into the public domain.

Anyone is free to copy, modify, publish, use, compile, sell, or
distribute this software, either in source code form or as a compiled
binary, for any purpose, commercial or non-commercial, and by any
means.

In jurisdictions that recognize copyright laws, the author or authors
of this software dedicate any and all copyright interest in the
software to the public domain. We make this dedication for the benefit
of the public at large and to the detriment of our heirs and
successors. We intend this dedication to be an overt act of
relinquishment in perpetuity of all present and future rights to this
software under copyright law.

THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND,
EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF
MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT.
IN NO EVENT SHALL THE AUTHORS BE LIABLE FOR ANY CLAIM, DAMAGES OR
OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE,
ARISING FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR
OTHER DEALINGS IN THE SOFTWARE.

For more information, please refer to <https://unlicense.org/>
```