### PR TITLE
Added ability to exclude menu paths from Unlimited Parameters

### DIFF
--- a/com.vrcfury.vrcfury/Editor/VF/Builder/Manager/MenuManager.cs
+++ b/com.vrcfury.vrcfury/Editor/VF/Builder/Manager/MenuManager.cs
@@ -165,6 +165,13 @@ namespace VF.Builder {
             return GetSubmenu(SplitPath(path));
         }
 
+        public VRCExpressionsMenu.Control[] FindControlsAtPath(string path) {
+            GetSubmenuAndItem(path, false, out _, out _, out var controlName, out var parentMenu);
+            if (!parentMenu) return null;
+
+            return FindControlsWithName(parentMenu, controlName);
+        }
+
         /**
          * Gets the VRC menu for the path specified, recursively creating if it doesn't exist.
          * If createFromControl is set, we will use it as the basis if creating the folder control is needed.

--- a/com.vrcfury.vrcfury/Editor/VF/Feature/UnlimitedParametersBuilder.cs
+++ b/com.vrcfury.vrcfury/Editor/VF/Feature/UnlimitedParametersBuilder.cs
@@ -118,9 +118,44 @@ namespace VF.Feature {
         }
 
         private IList<(string name,VRCExpressionParameters.ValueType type)> GetParamsToOptimize() {
+            // Calculate from all UnlimitedParametersExcludeBuilder components what variables should be excluded from optimization
+            var paramsToExclude = new HashSet<string>();
+            foreach (var excludePath in allFeaturesInRun.OfType<UnlimitedParametersExclude>()) {
+                var controls = manager.GetMenu().FindControlsAtPath(excludePath.path);
+
+                Debug.Log($"Excluding {controls.Length} items at {excludePath.path}");
+
+                if (controls.Length == 0) {
+                    Debug.Log($"Did not find menu items to exclude at {excludePath.path}");
+                }
+                else {
+                    foreach (var control in controls) {
+                        if (control.type == VRCExpressionsMenu.Control.ControlType.RadialPuppet) {
+                            paramsToExclude.Add(control.GetSubParameter(0)?.name);
+                        }
+                        if (control.type == VRCExpressionsMenu.Control.ControlType.Button
+                            || control.type == VRCExpressionsMenu.Control.ControlType.Toggle) {
+                            paramsToExclude.Add(control.parameter?.name);
+                        }
+                        if (control.type == VRCExpressionsMenu.Control.ControlType.TwoAxisPuppet) {
+                            paramsToExclude.Add(control.GetSubParameter(0)?.name);
+                            paramsToExclude.Add(control.GetSubParameter(1)?.name);
+                        }
+                        if (control.type == VRCExpressionsMenu.Control.ControlType.FourAxisPuppet) {
+                            paramsToExclude.Add(control.GetSubParameter(0)?.name);
+                            paramsToExclude.Add(control.GetSubParameter(1)?.name);
+                            paramsToExclude.Add(control.GetSubParameter(2)?.name);
+                            paramsToExclude.Add(control.GetSubParameter(3)?.name);
+                        }
+                    }
+                }
+            }
+
             var paramsToOptimize = new HashSet<(string,VRCExpressionParameters.ValueType)>();
+
             void AttemptToAdd(string paramName) {
                 if (string.IsNullOrEmpty(paramName)) return;
+                if (paramsToExclude.Contains(paramName)) return;
                 
                 var vrcParam = manager.GetParams().GetParam(paramName);
                 if (vrcParam == null) return;

--- a/com.vrcfury.vrcfury/Editor/VF/Feature/UnlimitedParametersExcludeBuilder.cs
+++ b/com.vrcfury.vrcfury/Editor/VF/Feature/UnlimitedParametersExcludeBuilder.cs
@@ -1,0 +1,28 @@
+using UnityEditor;
+using UnityEngine.UIElements;
+using VF.Feature.Base;
+using VF.Inspector;
+using VF.Model.Feature;
+using VF.Utils;
+
+namespace VF.Feature {
+    internal class UnlimitedParametersExcludeBuilder : FeatureBuilder<UnlimitedParametersExclude> {
+        public override string GetEditorTitle() {
+            return "Unlimited Parameters Exclusion";
+        }
+
+        public override VisualElement CreateEditor(SerializedProperty prop) {
+            var content = new VisualElement();
+            content.Add(VRCFuryEditorUtils.Info("This feature will allow you to exclude from the Unlimited Parameters component all variables associated with a given menu item."));
+
+            var pathProp = prop.FindPropertyRelative("path");
+            content.Add(MoveMenuItemBuilder.SelectButton(avatarObject, false, pathProp));
+
+            return content;
+        }
+
+        public override bool AvailableOnRootOnly() {
+            return false;
+        }
+    }
+}

--- a/com.vrcfury.vrcfury/Runtime/VF/Model/Feature.cs
+++ b/com.vrcfury.vrcfury/Runtime/VF/Model/Feature.cs
@@ -1022,6 +1022,11 @@ namespace VF.Model.Feature {
     [Serializable]
     internal class UnlimitedParameters : NewFeatureModel {
     }
+	
+	[Serializable]
+    internal class UnlimitedParametersExclude : NewFeatureModel {
+		public string path;
+    }
     
     [Serializable]
     internal class DescriptorDebug : NewFeatureModel {


### PR DESCRIPTION
I know the Unlimited Parameters feature is in beta, so no worries if this addition is perhaps too soon, but I figured I'd at least make this available in the event it fits with the desired design.


There are instances in which it's useful to puppet something through a radial menu, or have manual overrides in the menu for avatar features that usually trigger automatically.  Unlimited Parameters is a fantastic feature, but currently if you want to use it and also have certain menu options be responsive you have to use a workaround, as it will target all menu variables that fit its criteria.

To address this, I opted to create a new component that allows the user to provide a menu path, and then exclude from Unlimited Parameters all variables associated with that menu path.  I think this is reasonably intuitive as Unlimited Parameters works off of menu items.  It's also the easiest way to target menu items generated by VRCFury components like the toggle, that auto-generate their variable names during the build but will have user-specified menu paths.


Hope it's helpful!