### PR TITLE
Add a OGB haptics toggle to SPS at the component level.

### DIFF
--- a/com.vrcfury.vrcfury/Editor/VF/Inspector/VRCFuryHapticPlugEditor.cs
+++ b/com.vrcfury.vrcfury/Editor/VF/Inspector/VRCFuryHapticPlugEditor.cs
@@ -181,7 +181,13 @@ namespace VF.Inspector {
                 })
             ));
 
-            container.Add(GetHapticsSection());
+            var haptics = GetHapticsSection();
+            container.Add(haptics);
+            haptics.Add(VRCFuryEditorUtils.BetterProp(
+                        serializedObject.FindProperty("spsHaptic"),
+                        "Haptics",
+                        tooltip: "This is a hack."
+                    ));
 
             var adv = new Foldout {
                 text = "Advanced Plug Options",

--- a/com.vrcfury.vrcfury/Editor/VF/Inspector/VRCFuryHapticSocketEditor.cs
+++ b/com.vrcfury.vrcfury/Editor/VF/Inspector/VRCFuryHapticSocketEditor.cs
@@ -91,6 +91,11 @@ namespace VF.Inspector {
                 serializedObject.FindProperty("length"),
                 "Hand touch zone depth override in meters:\nNote, this zone is only used for hand touches, not plug interaction."
             ));
+            haptics.Add(VRCFuryEditorUtils.BetterProp(
+                serializedObject.FindProperty("spsHaptic"),
+                "Haptics",
+                tooltip: "This is a hack."
+            ));
             
             var adv = new Foldout {
                 text = "Advanced",

--- a/com.vrcfury.vrcfury/Editor/VF/Service/BakeHapticPlugsService.cs
+++ b/com.vrcfury.vrcfury/Editor/VF/Service/BakeHapticPlugsService.cs
@@ -130,7 +130,7 @@ namespace VF.Service {
             Debug.Log("Baking haptic component in " + plug.owner().GetPath() + " as " + name);
             
             // Haptics
-            if (HapticsToggleMenuItem.Get() && !plug.sendersOnly) {
+            if (HapticsToggleMenuItem.Get() && plug.spsHaptic && !plug.sendersOnly) {
                 // Haptic Receivers
                 var paramPrefix = "OGB/Pen/" + name.Replace('/','_');
                 var haptics = GameObjects.Create("Haptics", bakeRoot);

--- a/com.vrcfury.vrcfury/Editor/VF/Service/BakeHapticSocketsService.cs
+++ b/com.vrcfury.vrcfury/Editor/VF/Service/BakeHapticSocketsService.cs
@@ -115,7 +115,7 @@ namespace VF.Service {
                     });
 
                     VFGameObject haptics = null;
-                    if (HapticsToggleMenuItem.Get() && !socket.sendersOnly) {
+                    if (HapticsToggleMenuItem.Get() && socket.spsHaptic && !socket.sendersOnly) {
                         // Haptic receivers
 
                         // This is *90 because capsule length is actually "height", so we have to rotate it to make it a length

--- a/com.vrcfury.vrcfury/Runtime/VF/Component/VRCFuryHapticPlug.cs
+++ b/com.vrcfury.vrcfury/Runtime/VF/Component/VRCFuryHapticPlug.cs
@@ -11,6 +11,7 @@ namespace VF.Component {
         public bool autoPosition = true;
         public bool autoLength = true;
         public bool useBoneMask = true;
+        public bool spsHaptic = true;
         public GuidTexture2d textureMask = null;
         public float length;
         public bool autoRadius = true;

--- a/com.vrcfury.vrcfury/Runtime/VF/Component/VRCFuryHapticSocket.cs
+++ b/com.vrcfury.vrcfury/Runtime/VF/Component/VRCFuryHapticSocket.cs
@@ -28,6 +28,7 @@ namespace VF.Component {
         public bool addMenuItem = true;
         public GuidTexture2d menuIcon;
         public bool enableAuto = true;
+        public bool spsHaptic = true;
         public Vector3 position;
         public Vector3 rotation;
         [NonSerialized] public bool sendersOnly = false;


### PR DESCRIPTION
This PR adds a toggle to the SPS socket and plug components to enable or disable their OGB integration on an individual basis. A simple checkbox. Original project-wide toggling remains untouched.

Motivation: A certain avatar was past the 256 contact limit, and I felt the need to address the lack of the feature provided by this PR.