### PR TITLE
Fix FurySocket.GetActiveActions NullReferenceException

### DIFF
--- a/com.vrcfury.vrcfury/PublicApi/Components/FurySocket.cs
+++ b/com.vrcfury.vrcfury/PublicApi/Components/FurySocket.cs
@@ -39,6 +39,7 @@ namespace com.vrcfury.api.Components {
         }
 
         public FuryActionSet GetActiveActions() {
+            if (s.activeActions == null) s.activeActions = new State();
             return new FuryActionSet(s.activeActions);
         }
 


### PR DESCRIPTION
Fixes `FurySocket.GetActiveActions` throwing a `NullReferenceException` caused by `VRCFuryHapticSocket.activeActions` not being initialized.

https://github.com/VRCFury/VRCFury/commit/514c2c50e0b95541e442b7ce10493382d91c2f80 seems to have removed the null check.

```
The changes made in this contribution are free and unencumbered software
released into the public domain.

Anyone is free to copy, modify, publish, use, compile, sell, or
distribute this software, either in source code form or as a compiled
binary, for any purpose, commercial or non-commercial, and by any
means.

In jurisdictions that recognize copyright laws, the author or authors
of this software dedicate any and all copyright interest in the
software to the public domain. We make this dedication for the benefit
of the public at large and to the detriment of our heirs and
successors. We intend this dedication to be an overt act of
relinquishment in perpetuity of all present and future rights to this
software under copyright law.

THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND,
EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF
MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT.
IN NO EVENT SHALL THE AUTHORS BE LIABLE FOR ANY CLAIM, DAMAGES OR
OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE,
ARISING FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR
OTHER DEALINGS IN THE SOFTWARE.

For more information, please refer to <https://unlicense.org>
```