### PR TITLE
Folders

### DIFF
--- a/com.vrcfury.vrcfury/Editor/VF/Feature/FullControllerBuilder.cs
+++ b/com.vrcfury.vrcfury/Editor/VF/Feature/FullControllerBuilder.cs
@@ -97,7 +97,7 @@ namespace VF.Feature {
 
                 var copy = menu.Clone();
                 copy.RewriteParameters(RewriteParamName);
-                var prefix = MenuManager.SplitPath(m.prefix);
+                var prefix = MenuManager.SplitPath(MenuManager.prependFolders(m.prefix, featureBaseObject));
                 avatarMenu.MergeMenu(prefix, copy);
             }
 

--- a/com.vrcfury.vrcfury/Editor/VF/Feature/MenuFolderBuilder.cs
+++ b/com.vrcfury.vrcfury/Editor/VF/Feature/MenuFolderBuilder.cs
@@ -1,0 +1,26 @@
+using UnityEditor;
+using UnityEngine.UIElements;
+using VF.Builder;
+using VF.Feature.Base;
+using VF.Inspector;
+using VF.Model.Feature;
+
+namespace VF.Feature {
+    [FeatureTitle("Menu Folder")]
+    internal class MenuFolderBuilder : FeatureBuilder<MenuFolder> {
+        
+        [FeatureEditor]
+        public static VisualElement Editor(SerializedProperty prop, VFGameObject avatarObject, VFGameObject componentObject) {
+            var content = new VisualElement();
+            content.Add(VRCFuryEditorUtils.Info("VRCFury Toggles and Full Controllers that are children of this object will automatically be placed in the specified subfolder."));
+
+            var folderPath = prop.FindPropertyRelative("folderPath");
+            
+            content.Add(MoveMenuItemBuilder.SelectButton(avatarObject, componentObject.parent, true, folderPath, label: "Folder Path"));
+
+            return content;
+        }
+
+      
+    }
+}

--- a/com.vrcfury.vrcfury/Editor/VF/Feature/MenuFolderBuilder.cs.meta
+++ b/com.vrcfury.vrcfury/Editor/VF/Feature/MenuFolderBuilder.cs.meta
@@ -1,0 +1,11 @@
+fileFormatVersion: 2
+guid: 41515cd50f4bf2b4cb75db361b2e0058
+MonoImporter:
+  externalObjects: {}
+  serializedVersion: 2
+  defaultReferences: []
+  executionOrder: 0
+  icon: {instanceID: 0}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/com.vrcfury.vrcfury/Editor/VF/Feature/MoveMenuItemBuilder.cs
+++ b/com.vrcfury.vrcfury/Editor/VF/Feature/MoveMenuItemBuilder.cs
@@ -25,8 +25,8 @@ namespace VF.Feature {
             var fromPath = prop.FindPropertyRelative("fromPath");
             var toPath = prop.FindPropertyRelative("toPath");
             
-            content.Add(SelectButton(avatarObject, false, fromPath, label: "From Path"));
-            content.Add(SelectButton(avatarObject, true, toPath, label: "To Path", append: () => {
+            content.Add(SelectButton(avatarObject, null, false, fromPath, label: "From Path"));
+            content.Add(SelectButton(avatarObject, null, true, toPath, label: "To Path", append: () => {
                 return GetLastMenuSlug(fromPath.stringValue, "New Thing");
             }));
 
@@ -45,6 +45,7 @@ namespace VF.Feature {
 
         public static VisualElement SelectButton(
             [CanBeNull] VFGameObject avatarObject,
+            [CanBeNull] VFGameObject componentObject,
             bool foldersOnly,
             SerializedProperty prop,
             string label = "Menu Path",
@@ -58,6 +59,11 @@ namespace VF.Feature {
                 if (append != null) {
                     if (path != "") path += "/";
                     path += append();
+                }
+                if (componentObject != null) {
+                    var folderPrefix = MenuManager.prependFolders("", componentObject);
+                    if (path.StartsWith(folderPrefix)) path = path.Replace(folderPrefix,"");
+                    if (path.StartsWith("/")) path = path.Substring(1);
                 }
                 prop.stringValue = path;
                 prop.serializedObject.ApplyModifiedProperties();

--- a/com.vrcfury.vrcfury/Editor/VF/Feature/ReorderMenuItemBuilder.cs
+++ b/com.vrcfury.vrcfury/Editor/VF/Feature/ReorderMenuItemBuilder.cs
@@ -17,7 +17,7 @@ namespace VF.Feature {
             content.Add(VRCFuryEditorUtils.Info("This feature will change the position of a menu item within its folder."));
 
             var pathProp = prop.FindPropertyRelative("path");
-            content.Add(MoveMenuItemBuilder.SelectButton(avatarObject, false, pathProp));
+            content.Add(MoveMenuItemBuilder.SelectButton(avatarObject, null, false, pathProp));
 
             content.Add(VRCFuryEditorUtils.Prop(prop.FindPropertyRelative("position"), "New Position",
                 tooltip: "This is the position that you want to move the menu item to.\n\nExamples:\n" +

--- a/com.vrcfury.vrcfury/Editor/VF/Feature/SetIconBuilder.cs
+++ b/com.vrcfury.vrcfury/Editor/VF/Feature/SetIconBuilder.cs
@@ -12,12 +12,12 @@ namespace VF.Feature {
     internal class SetIconBuilder : FeatureBuilder<SetIcon> {
         
         [FeatureEditor]
-        public static VisualElement Editor(SerializedProperty prop, VFGameObject avatarObject) {
+        public static VisualElement Editor(SerializedProperty prop, VFGameObject avatarObject, VFGameObject componentObject) {
             var content = new VisualElement();
             content.Add(VRCFuryEditorUtils.Info("This feature will override the menu icon for the given menu path. You can use slashes to look in subfolders."));
 
             var pathProp = prop.FindPropertyRelative("path");
-            content.Add(MoveMenuItemBuilder.SelectButton(avatarObject, false, pathProp));
+            content.Add(MoveMenuItemBuilder.SelectButton(avatarObject, componentObject, false, pathProp));
             
             content.Add(VRCFuryEditorUtils.Prop(prop.FindPropertyRelative("icon"), "Icon"));
             return content;

--- a/com.vrcfury.vrcfury/Editor/VF/Feature/SpsOptionsBuilder.cs
+++ b/com.vrcfury.vrcfury/Editor/VF/Feature/SpsOptionsBuilder.cs
@@ -19,6 +19,7 @@ namespace VF.Feature {
             var pathProp = prop.FindPropertyRelative("menuPath");
             c.Add(MoveMenuItemBuilder.SelectButton(
                 avatarObject,
+                null,
                 true,
                 pathProp,
                 append: () => "SPS",

--- a/com.vrcfury.vrcfury/Editor/VF/Feature/ToggleBuilder.cs
+++ b/com.vrcfury.vrcfury/Editor/VF/Feature/ToggleBuilder.cs
@@ -122,13 +122,13 @@ namespace VF.Feature {
                 if (addMenuItem) {
                     if (model.holdButton) {
                         menu.NewMenuButton(
-                            model.name,
+                            MenuManager.prependFolders(model.name, featureBaseObject),
                             param,
                             icon: model.enableIcon ? model.icon?.Get() : null
                         );
                     } else {
                         menu.NewMenuToggle(
-                            model.name,
+                            MenuManager.prependFolders(model.name, featureBaseObject),
                             param,
                             icon: model.enableIcon ? model.icon?.Get() : null
                         );
@@ -389,6 +389,7 @@ namespace VF.Feature {
                     advMenu.AddItem(new GUIContent("Select Menu Folder"), false, () => {
                         MoveMenuItemBuilder.SelectButton(
                             avatarObject,
+                            componentObject,
                             true,
                             pathProp,
                             append: () => MoveMenuItemBuilder.GetLastMenuSlug(pathProp.stringValue, "New Toggle"),

--- a/com.vrcfury.vrcfury/Editor/VF/Utils/MenuEstimator.cs
+++ b/com.vrcfury.vrcfury/Editor/VF/Utils/MenuEstimator.cs
@@ -1,5 +1,6 @@
 ﻿using System.Collections.Generic;
 using System.Linq;
+using UnityEngine;
 using VF.Builder;
 using VF.Model;
 using VF.Model.Feature;
@@ -9,10 +10,10 @@ using VRC.SDK3.Avatars.ScriptableObjects;
 
 namespace VF.Utils {
     internal static class MenuEstimator {
+
         public static MenuManager Estimate(VFGameObject avatarObj) {
-            var features = avatarObj.GetComponentsInSelfAndChildren<VRCFury>()
+            var builders = avatarObj.GetComponentsInSelfAndChildren<VRCFury>()
                 .Where(c => !EditorOnlyUtils.IsInsideEditorOnly(c.owner()))
-                .SelectMany(c => c.GetAllFeatures())
                 .ToList();
 
             var root = VrcfObjectFactory.Create<VRCExpressionsMenu>();
@@ -24,21 +25,24 @@ namespace VF.Utils {
                 if (origMenu != null) merged.MergeMenu(origMenu);
             }
 
-            foreach (var fullController in features.OfType<FullController>()) {
-                foreach (var menuEntry in fullController.menus) {
-                    var menu = menuEntry.menu.Get();
-                    if (menu == null) continue;
-                    var prefix = MenuManager.SplitPath(menuEntry.prefix);
-                    merged.MergeMenu(prefix, menu);
+            foreach (var builder in builders) {
+                var features = builder.GetAllFeatures().ToList();
+                foreach (var fullController in features.OfType<FullController>()) {
+                    foreach (var menuEntry in fullController.menus) {
+                        var menu = menuEntry.menu.Get();
+                        if (menu == null) continue;
+                        var prefix = MenuManager.SplitPath(MenuManager.prependFolders(menuEntry.prefix, builder.gameObject));
+                        merged.MergeMenu(prefix, menu);
+                    }
                 }
-            }
 
-            foreach (var toggle in features.OfType<Toggle>()) {
-                var hasTitle = !string.IsNullOrEmpty(toggle.name);
-                var hasIcon = toggle.enableIcon && toggle.icon?.Get() != null;
-                var addMenuItem = toggle.addMenuItem && (hasTitle || hasIcon);
-                if (addMenuItem) {
-                    merged.NewMenuButton(toggle.name);
+                foreach (var toggle in features.OfType<Toggle>()) {
+                    var hasTitle = !string.IsNullOrEmpty(toggle.name);
+                    var hasIcon = toggle.enableIcon && toggle.icon?.Get() != null;
+                    var addMenuItem = toggle.addMenuItem && (hasTitle || hasIcon);
+                    if (addMenuItem) {
+                        merged.NewMenuButton(MenuManager.prependFolders(toggle.name, builder.gameObject));
+                    }
                 }
             }
 

--- a/com.vrcfury.vrcfury/Editor/VF/Utils/MenuManager.cs
+++ b/com.vrcfury.vrcfury/Editor/VF/Utils/MenuManager.cs
@@ -1,9 +1,17 @@
 using System;
 using System.Collections;
 using System.Collections.Generic;
+using System.IO;
 using System.Linq;
 using System.Text.RegularExpressions;
 using UnityEngine;
+using VF.Component;
+using VF.Feature;
+using VF.Feature.Base;
+using VF.Injector;
+using VF.Model;
+using VF.Model.Feature;
+using VF.Service;
 using VF.Utils.Controller;
 using VRC.SDK3.Avatars.ScriptableObjects;
 
@@ -45,6 +53,20 @@ namespace VF.Utils {
                 .Split('/')
                 .Select(s => s.Replace("REALSLASH", "/"))
                 .ToArray();
+        }
+
+        public static string prependFolders(string path, GameObject gameObject) {
+            if (gameObject == null) return path;
+            foreach (var component in gameObject.GetComponentsInParent<VRCFury>()) {
+                var folder = component.content as MenuFolder;
+                if (folder == null) continue;
+                var folderPath = folder.folderPath;
+                if (string.IsNullOrWhiteSpace(folderPath)) continue;
+                path = folderPath + "/" + path;
+            }
+            if (path.EndsWith('/')) path = path.Substring(0, path.Length - 1);
+            return path;
+           
         }
 
         private VRCExpressionsMenu.Control NewMenuItem(string path) {

--- a/com.vrcfury.vrcfury/Runtime/VF/Model/Feature/MenuFolder.cs
+++ b/com.vrcfury.vrcfury/Runtime/VF/Model/Feature/MenuFolder.cs
@@ -1,0 +1,8 @@
+﻿using System;
+
+namespace VF.Model.Feature {
+    [Serializable]
+    internal class MenuFolder : NewFeatureModel {
+        public string folderPath;
+    }
+}

--- a/com.vrcfury.vrcfury/Runtime/VF/Model/Feature/MenuFolder.cs.meta
+++ b/com.vrcfury.vrcfury/Runtime/VF/Model/Feature/MenuFolder.cs.meta
@@ -1,0 +1,11 @@
+fileFormatVersion: 2
+guid: ee3d6f74e8225d847a3524a950f75e94
+MonoImporter:
+  externalObjects: {}
+  serializedVersion: 2
+  defaultReferences: []
+  executionOrder: 0
+  icon: {instanceID: 0}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 


### PR DESCRIPTION
Added new VRCF component called Menu Folder, which causes all toggles and full controllers that are children of the gameobject with the menu folder to be automatically placed in the given subfolder. This helps support the usecases of people who "build" their menus in their hierarchy. The menu estimator has also been adjusted to handle these new gameobjects and predict them accurately.

