### PR TITLE
Add fetching target bones

### DIFF
--- a/com.vrcfury.vrcfury/PublicApi/FuryUtils.cs
+++ b/com.vrcfury.vrcfury/PublicApi/FuryUtils.cs
@@ -1,6 +1,10 @@
-﻿using JetBrains.Annotations;
+﻿using System;
+using System.Collections.Generic;
+using JetBrains.Annotations;
 using UnityEngine;
 using VF.Builder;
+using VF.Model;
+using VF.Model.Feature;
 
 namespace com.vrcfury.api {
     /** Useful code utilities provided by VRCFury */
@@ -12,6 +16,29 @@ namespace com.vrcfury.api {
          */
         public static GameObject GetBone(GameObject avatarObject, HumanBodyBones bone) {
             return VRCFArmatureUtils.FindBoneOnArmatureOrException(avatarObject, bone);
+        }
+        
+        /// <summary>
+        /// Returns the parented target objects and the string offset, null if an armatureLink isn't present on object.
+        /// If GameObject is null, then HumanBodyBones is the option selected.
+        /// </summary>
+        /// <returns>(targetObject, target skeleton bone, offset) </returns>
+        public static List<(GameObject, HumanBodyBones, string)> GetArmatureLinkTargets(GameObject obj) {
+            // Attempt to get the VRCFury component from the GameObject
+            var vf = obj.GetComponent<VRCFury>();
+            if (vf == null) {
+                Debug.LogError("VRCFury component not found on this GameObject.");
+                return null;
+            }
+    
+            // Cast the content to ArmatureLink
+            ArmatureLink armatureLink = vf.content as ArmatureLink;
+            if (armatureLink == null) {
+                Debug.LogError("Object does not contain an instance of ArmatureLink.");
+                return null;
+            }
+
+            return armatureLink.GetLinkTargets();
         }
     }
 }

--- a/com.vrcfury.vrcfury/Runtime/VF/Model/Feature/ArmatureLink.cs
+++ b/com.vrcfury.vrcfury/Runtime/VF/Model/Feature/ArmatureLink.cs
@@ -1,6 +1,8 @@
 ﻿using System;
 using System.Collections.Generic;
 using System.Linq;
+using System.Runtime.CompilerServices;
+using UnityEditor.UI;
 using UnityEngine;
 using VRC.SDK3.Avatars.Components;
 
@@ -138,6 +140,16 @@ namespace VF.Model.Feature {
                 if (skin.bones.Any(bone => bone != null && bone.IsChildOf(obj))) return true;
             }
             return false;
+        }
+
+        // Provide export function 
+        public List<(GameObject, HumanBodyBones, string)> GetLinkTargets() {
+            var outList = new List<(GameObject, HumanBodyBones, string)>();
+            foreach (LinkTo link in linkTo) {
+                outList.Add((link.obj, link.bone, link.offset));
+            }
+
+            return outList;
         }
     }
 }


### PR DESCRIPTION
I would like to be able to retrieve the object or bones targeted by an `armatureLinker` internally in my own unity package. 

I figure this interface would be simple and easy enough to keep up with if needed, because the base idea of a linker is to ultimately target a user-specified `GameObject`. This guarantees that there will be a `GameObject` somewhere in the `armatureLinker` regardless of the form it takes. Generalizing away the specific transforms is currently done through the `HumanBodyBones`, which is a stable Unity-Based representation and has been a standard for a long time now. 

Also since this information is static and not generated or affected during upload, it should always be available without substantial computation.

I don't see a reason any of the core requirements for providing this information to change beyond what a small function could merge. 

Please let me know if there are any other concerns you have.