### PR TITLE
Vertex Animation Textures inside of SPS

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -114,4 +114,4 @@ For more information, please refer to <https://unlicense.org>
 * Ximmer-VR
   * Made Toggle sliders work with global parameters
 * Zaytha
-  * Vertex Animation Textures with SPS
+  * Added Vertex Animation Textures with SPS

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -113,3 +113,5 @@ For more information, please refer to <https://unlicense.org>
   * Added public api for SPS Socket creation
 * Ximmer-VR
   * Made Toggle sliders work with global parameters
+* Zaytha
+  * Vertex Animation Textures with SPS

--- a/com.vrcfury.vrcfury/Editor/VF/Builder/Haptics/SpsConfigurer.cs
+++ b/com.vrcfury.vrcfury/Editor/VF/Builder/Haptics/SpsConfigurer.cs
@@ -15,6 +15,16 @@ namespace VF.Builder.Haptics {
         private const string SpsBakedLength = "_SPS_BakedLength";
         private const string SpsBake = "_SPS_Bake";
 
+        private const string SpsVATEnabled = "_SPS_VAT_Enabled";
+        private const string SpsVATInterpolate = "_SPS_VAT_Interpolate";
+        private const string SpsVATPlaybackSpeed = "_SPS_VAT_PlaybackSpeed";
+        private const string SpsVATPosTexture = "_SPS_VAT_PosTexture";
+        private const string SpsVATRotTexture = "_SPS_VAT_RotTexture";
+        private const string SpsVATFPS = "_SPS_VAT_FPS";
+        private const string SpsVATFrameCount = "_SPS_VAT_FrameCount";
+        private const string SpsVATAnimMin = "_SPS_VAT_AnimMin";
+        private const string SpsVATAnimMax = "_SPS_VAT_AnimMax";
+
         public static void ConfigureSpsMaterial(
             SkinnedMeshRenderer skin,
             Material m,
@@ -56,10 +66,51 @@ namespace VF.Builder.Haptics {
                     m.SetFloat("_SPS_Blendshape" + i, skin.GetBlendShapeWeight(name));
                 }
             }
+
+            m.SetFloat(SpsVATEnabled, plug.enableVat ? 1 : 0);
+            m.SetFloat(SpsVATInterpolate, plug.vatInterpolate ? 1 : 0);
+            m.SetFloat(SpsVATPlaybackSpeed, plug.vatPlaybackSpeed);
+            m.SetTexture(SpsVATPosTexture, MakeReadable(plug.vatPosTexture?.Get(), "Vat Pos Texture"));
+            m.SetTexture(SpsVATRotTexture, MakeReadable(plug.vatRotTexture?.Get(), "Vat Rot Texture"));
+            m.SetFloat(SpsVATFPS, plug.vatFPS);
+            m.SetFloat(SpsVATFrameCount, plug.vatFrameCount);
+            m.SetFloat(SpsVATAnimMin, plug.vatAnimMin);
+            m.SetFloat(SpsVATAnimMax, plug.vatAnimMax);
         }
 
         public static bool IsSps(Material mat) {
             return mat != null && mat.HasProperty(SpsBake);
+        }
+
+        // This is from PlugMaskGenerator, need it to convert GuidTexture2d into texture2d
+        // Made changes to read guidtextured as a signed ARGBHalf
+        // https://support.unity.com/hc/en-us/articles/206486626-How-can-I-get-pixels-from-unreadable-textures-
+        private static Texture2D MakeReadable(Texture2D texture, string texture_name) {
+            if (texture == null) return null;
+            if (texture.isReadable) return texture;
+            var tmp = RenderTexture.GetTemporary(
+                texture.width,
+                texture.height,
+                0,
+                RenderTextureFormat.ARGBHalf, // Need to get a signed texture
+                RenderTextureReadWrite.Linear);
+            Graphics.Blit(texture, tmp);
+            RenderTexture previous = RenderTexture.active;
+            RenderTexture.active = tmp;
+            Texture2D myTexture2D = new Texture2D(texture.width, texture.height, TextureFormat.RGBAHalf, false, true);
+            VrcfObjectFactory.Register(myTexture2D);
+            myTexture2D.ReadPixels(new Rect(0, 0, tmp.width, tmp.height), 0, 0);
+
+            myTexture2D.name += texture_name;
+
+            myTexture2D.wrapMode = TextureWrapMode.Clamp;
+            myTexture2D.filterMode = FilterMode.Point;
+
+            myTexture2D.Apply();
+
+            RenderTexture.active = previous;
+            RenderTexture.ReleaseTemporary(tmp);
+            return myTexture2D;
         }
     }
 }

--- a/com.vrcfury.vrcfury/Editor/VF/Inspector/VRCFuryHapticPlugEditor.cs
+++ b/com.vrcfury.vrcfury/Editor/VF/Inspector/VRCFuryHapticPlugEditor.cs
@@ -183,6 +183,28 @@ namespace VF.Inspector {
 
             container.Add(GetHapticsSection());
 
+            // Vertex Animation Textures
+            var enableVat = serializedObject.FindProperty("enableVat");
+            container.Add(VRCFuryEditorUtils.BetterProp(enableVat, "Enable Vertex Animation Textures"));
+            container.Add(VRCFuryEditorUtils.RefreshOnChange(() => {
+                var c = new VisualElement();
+                if (enableVat.boolValue) {
+                    var vatBox = VRCFuryEditorUtils.Section("Vertex Animation Textures");
+                    c.Add(vatBox);
+                    vatBox.Add(VRCFuryEditorUtils.BetterProp(serializedObject.FindProperty("vatInterpolate"),"Interpolate"));
+                    vatBox.Add(VRCFuryEditorUtils.BetterProp(serializedObject.FindProperty("vatPlaybackSpeed"), "Playback speed"));
+                    vatBox.Add(VRCFuryEditorUtils.BetterProp(serializedObject.FindProperty("vatPosTexture"), "Position Texture"));
+                    vatBox.Add(VRCFuryEditorUtils.BetterProp(serializedObject.FindProperty("vatRotTexture"), "Rotatoin Texture"));
+                    vatBox.Add(VRCFuryEditorUtils.BetterProp(serializedObject.FindProperty("vatFPS"), "FPS"));
+                    vatBox.Add(VRCFuryEditorUtils.BetterProp(serializedObject.FindProperty("vatFrameCount"), "FrameCount"));
+                    vatBox.Add(VRCFuryEditorUtils.Info(
+                        "These Anim values should be usign the range system like depth animations do, but I don't know how to use that system so I'm hardcoding the values for now"));
+                    vatBox.Add(VRCFuryEditorUtils.BetterProp(serializedObject.FindProperty("vatAnimMin"), "Anim Min Distance"));
+                    vatBox.Add(VRCFuryEditorUtils.BetterProp(serializedObject.FindProperty("vatAnimMax"), "Anim Max Distance"));
+                }
+                return c;
+            }, enableVat));
+
             var adv = new Foldout {
                 text = "Advanced Plug Options",
                 value = false

--- a/com.vrcfury.vrcfury/Runtime/VF/Component/VRCFuryHapticPlug.cs
+++ b/com.vrcfury.vrcfury/Runtime/VF/Component/VRCFuryHapticPlug.cs
@@ -35,6 +35,16 @@ namespace VF.Component {
         public List<VRCFuryHapticSocket.DepthActionNew> depthActions2 = new List<VRCFuryHapticSocket.DepthActionNew>();
         public bool useHipAvoidance = true;
 
+        public bool enableVat = false;
+        public bool vatInterpolate = true;
+        public float vatPlaybackSpeed = 1;
+        public GuidTexture2d vatPosTexture = null;
+        public GuidTexture2d vatRotTexture = null;
+        public float vatFPS = 24;
+        public float vatFrameCount;
+        public float vatAnimMin = 0;
+        public float vatAnimMax = 0;
+
         [Obsolete] public bool configureSps = false;
         [Obsolete] public bool spsBoneMask = true;
         [Obsolete] public GuidTexture2d spsTextureMask = null;

--- a/com.vrcfury.vrcfury/SPS/sps_globals.cginc
+++ b/com.vrcfury.vrcfury/SPS/sps_globals.cginc
@@ -49,4 +49,14 @@ float _SPS_Enabled;
 float _SPS_Overrun;
 float _SPS_Target_LL_Lights;
 
+float _SPS_VAT_Enabled;
+float _SPS_VAT_Interpolate;
+float _SPS_VAT_PlaybackSpeed;
+sampler2D _SPS_VAT_PosTexture;
+sampler2D _SPS_VAT_RotTexture;
+float _SPS_VAT_FPS;
+float _SPS_VAT_FrameCount;
+float _SPS_VAT_AnimMin;
+float _SPS_VAT_AnimMax;
+
 #endif

--- a/com.vrcfury.vrcfury/SPS/sps_main.cginc
+++ b/com.vrcfury.vrcfury/SPS/sps_main.cginc
@@ -3,6 +3,7 @@
 #include "sps_plus.cginc"
 #include "sps_bake.cginc"
 #include "sps_utils.cginc"
+#include "sps_vat.cginc"
 
 // SPS Penetration Shader
 void sps_apply_real(inout float3 vertex, inout float3 normal, inout float3 tangent, uint vertexId, inout float4 color, SpsInputs all)
@@ -27,8 +28,6 @@ void sps_apply_real(inout float3 vertex, inout float3 normal, inout float3 tange
 	bakedNormal = modCopy.SPS_STRUCT_NORMAL_NAME.xyz;
 	bakedTangent = modCopy.SPS_STRUCT_TANGENT_NAME.xyz;
 #endif
-
-	bakedVertex *= (_SPS_Length / _SPS_BakedLength);
 	
 	if (active == 0) return;
 
@@ -93,6 +92,17 @@ void sps_apply_real(inout float3 vertex, inout float3 normal, inout float3 tange
 
 	rootPos *= (1-shrinkLerp);
 	orfDistance *= (1-shrinkLerp);
+
+	// VAT Patch
+	if(_SPS_VAT_Enabled == 1) {
+		float dist_a = _SPS_Length - (_SPS_Length * _SPS_VAT_AnimMax);
+		float dist_b = _SPS_Length - (_SPS_Length * _SPS_VAT_AnimMin);
+		float dist_fitted = sps_saturated_map(orfDistance, dist_a, dist_b);
+		sps_vertex_animation_texture(bakedVertex, bakedNormal, bakedTangent, all.uv1, dist_fitted);
+	}
+
+	// Need to do SPS before scale is applied
+	bakedVertex *= (_SPS_Length / _SPS_BakedLength);
 
 	float3 bezierPos;
 	float3 bezierForward;

--- a/com.vrcfury.vrcfury/SPS/sps_props.cginc
+++ b/com.vrcfury.vrcfury/SPS/sps_props.cginc
@@ -26,3 +26,13 @@ _SPS_Blendshape15("Blendshape 15", Float) = 0
 _SPS_Plus_Enabled("_SPS_Plus_Enabled", Float) = 0
 _SPS_Plus_Ring("_SPS_Plus_Ring", Float) = 0
 _SPS_Plus_Hole("_SPS_Plus_Hole", Float) = 0
+
+_SPS_VAT_Enabled("_SPS_VAT_Enable", Float) = 0
+_SPS_VAT_Interpolate("_SPS_VAT_Interpoalte", Float) = 0
+_SPS_VAT_PlaybackSpeed("_SPS_VAT_PlaybackSpeed", Float) = 0
+_SPS_VAT_PosTexture("PosTexture", 2D) = "white" {}
+_SPS_VAT_RotTexture("RotTexture", 2D) = "white" {}
+_SPS_VAT_FPS("_SPS_VAT_FPS", Float) = 0
+_SPS_VAT_FrameCount("_SPS_VAT_FrameCount", Float) = 0
+_SPS_VAT_AnimMin("_SPS_VAT_AnimMin", Float) = 0
+_SPS_VAT_AnimMax("_SPS_VAT_AnimMax", Float) = 0

--- a/com.vrcfury.vrcfury/SPS/sps_vat.cginc
+++ b/com.vrcfury.vrcfury/SPS/sps_vat.cginc
@@ -1,0 +1,92 @@
+// helper function to get current frame and next frames offset
+float2 sps_vat_get_uv_offset(float frame, float y_ratio, float y_cord, float x_cord)
+{
+    // progress describes how far the animation is along the VAT, from 0 to 1
+    float progress = frame * (1/_SPS_VAT_FrameCount);
+    float shifted_y_uv = 1 - (y_cord + (progress * y_ratio));
+    // uv postition with shifted offset on the y for current frame
+    float2 frame_uv = float2(x_cord, shifted_y_uv);
+
+    return frame_uv;
+}
+// both normal and optional tangents are stored in the same rotation map, this decodes that for each case
+float3 sps_vat_decode_rotation_texture(float4 data, float3 key)
+{
+    float3 x1 = data.w * key;
+    float3 x2 = cross(data.xyz, key);
+    float3 x3 = x1 + x2;
+    float3 x4 = cross(data.xyz, x3) * (2,2,2) + key;
+    return x4;
+}
+
+void sps_vertex_animation_texture(inout float3 vertex, inout float3 normal, inout float3 tangent, in float2 uv, in float pen_amt)
+{
+    float x_uv_cord = uv.x;
+    float y_uv_cord = (1 - uv.y);
+
+    // find active frame
+    float active_frame = floor(pen_amt * (_SPS_VAT_FrameCount - 1));
+
+    // modulo by the frame range to find current frame, modified removes one to skip 1st frame
+    float current_frame = fmod((active_frame), _SPS_VAT_FrameCount);
+    // don't sub to find next frame
+    float next_frame = fmod(active_frame+1, _SPS_VAT_FrameCount);
+
+    // get the offset for curret and next frame
+    float2 current_frame_uv = sps_vat_get_uv_offset(current_frame, pixel_ratio_y, y_uv_cord, x_uv_cord);
+    float2 next_frame_uv = sps_vat_get_uv_offset(next_frame, pixel_ratio_y, y_uv_cord, x_uv_cord);
+
+    // sample positiion texture with offset uv for current and next frame
+    float4 pos_offset = tex2Dlod(_SPS_VAT_PosTexture, float4(current_frame_uv, 0, 0));
+    float4 next_pos_offset = tex2Dlod(_SPS_VAT_PosTexture, float4(next_frame_uv, 0, 0));
+
+    // sample rotation texture for normal
+    float4 rotation_sample = tex2Dlod(_SPS_VAT_RotTexture, float4(current_frame_uv, 0, 0));
+    float4 next_rotation_sample = tex2Dlod(_SPS_VAT_RotTexture, float4(next_frame_uv, 0, 0));
+
+    // normal map from rotation texture
+    float3 normal_offset = sps_vat_decode_rotation_texture(rotation_sample, float3(0,1,0));
+    float3 next_normal_offset = sps_vat_decode_rotation_texture(next_rotation_sample, float3(0,1,0));
+
+    // tangnet map from rotation texture
+    float3 tangent_offset = sps_vat_decode_rotation_texture(rotation_sample, float3(-1,0,0));
+    float3 next_tangent_offset = sps_vat_decode_rotation_texture(next_rotation_sample, float3(-1,0,0));
+
+    // apply the offset to mesh
+
+    // step function for conditonals,
+    // 0 if false, 1 if true, using the modified houdini exporter, static points uv's are on the left side and should be ignored
+    float static_point_conditional = step(0.0001, uv.x);
+
+    // no interpolation
+    if (!_SPS_VAT_Interpolate || (current_frame != 0 && next_frame == 0))
+    {
+        if (static_point_conditional) // only effect points that aren't static in the baked animation
+        {
+            vertex += pos_offset.xyz;
+            normal = normalize(normal_offset);
+            tangent = normalize(tangent_offset);
+        }
+        
+    }
+    // interpolation
+    else
+    {
+        float interpolation_alpha = 0;
+        interpolation_alpha = pen_amt * (_SPS_VAT_FrameCount);
+
+        // find the fractional value for the lerp amount
+        interpolation_alpha = frac(interpolation_alpha);
+        // apply lerp value to offset
+        float3 lerp_pos = lerp(pos_offset.xyz, next_pos_offset.xyz, interpolation_alpha);
+        float3 lerp_normal = lerp(normal_offset, next_normal_offset, interpolation_alpha);
+        float3 lerp_tangent = lerp(tangent_offset, next_tangent_offset, interpolation_alpha);
+
+        if (static_point_conditional) // only effect points that aren't static in the baked animation
+        {
+            vertex += lerp_pos;
+            normal = normalize(lerp_normal);
+            tangent = normalize(lerp_tangent);
+        }
+    }
+}

--- a/com.vrcfury.vrcfury/SPS/sps_vat.cginc
+++ b/com.vrcfury.vrcfury/SPS/sps_vat.cginc
@@ -1,9 +1,9 @@
 // helper function to get current frame and next frames offset
-float2 sps_vat_get_uv_offset(float frame, float y_ratio, float y_cord, float x_cord)
+float2 sps_vat_get_uv_offset(float frame, float y_cord, float x_cord)
 {
     // progress describes how far the animation is along the VAT, from 0 to 1
     float progress = frame * (1/_SPS_VAT_FrameCount);
-    float shifted_y_uv = 1 - (y_cord + (progress * y_ratio));
+    float shifted_y_uv = 1 - (y_cord + progress);
     // uv postition with shifted offset on the y for current frame
     float2 frame_uv = float2(x_cord, shifted_y_uv);
 
@@ -33,8 +33,8 @@ void sps_vertex_animation_texture(inout float3 vertex, inout float3 normal, inou
     float next_frame = fmod(active_frame+1, _SPS_VAT_FrameCount);
 
     // get the offset for curret and next frame
-    float2 current_frame_uv = sps_vat_get_uv_offset(current_frame, pixel_ratio_y, y_uv_cord, x_uv_cord);
-    float2 next_frame_uv = sps_vat_get_uv_offset(next_frame, pixel_ratio_y, y_uv_cord, x_uv_cord);
+    float2 current_frame_uv = sps_vat_get_uv_offset(current_frame, y_uv_cord, x_uv_cord);
+    float2 next_frame_uv = sps_vat_get_uv_offset(next_frame, y_uv_cord, x_uv_cord);
 
     // sample positiion texture with offset uv for current and next frame
     float4 pos_offset = tex2Dlod(_SPS_VAT_PosTexture, float4(current_frame_uv, 0, 0));

--- a/com.vrcfury.vrcfury/SPS/sps_vat.cginc.meta
+++ b/com.vrcfury.vrcfury/SPS/sps_vat.cginc.meta
@@ -1,0 +1,7 @@
+fileFormatVersion: 2
+guid: 181f8fbcbab1f3d45a50adf927da4aff
+ShaderIncludeImporter:
+  externalObjects: {}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 


### PR DESCRIPTION
This PR adds [Vertex Animation Textures](https://www.sidefx.com/docs/houdini/nodes/out/labs--vertex_animation_textures-3.0.html) control inside of VRCFury, instead of targeting VAT's in a base shader.
This allows for using VATs with SPS with any base shader.

**Issues:**
- The current implementation of this edit expects that the base shader has a second uv channel. If the base shader doesn't support a secondary uv channel (like the standard shader), sps will fail to compile. There is a `_SPS_VAT_Enabled` variable but am unsure how to go about removing the uv1 call if the variable is false.
- In the `VRCFuryHapticPlugEditor.cs`, I'm not sure how to use the penetration range system like depths animations do, and am using two floats then scaling those by `_SPS_Length` in `sps_main.cginc`. While this system works, using the proper UI system would be better.



```
The changes made in this contribution are free and unencumbered software
released into the public domain.

Anyone is free to copy, modify, publish, use, compile, sell, or
distribute this software, either in source code form or as a compiled
binary, for any purpose, commercial or non-commercial, and by any
means.

In jurisdictions that recognize copyright laws, the author or authors
of this software dedicate any and all copyright interest in the
software to the public domain. We make this dedication for the benefit
of the public at large and to the detriment of our heirs and
successors. We intend this dedication to be an overt act of
relinquishment in perpetuity of all present and future rights to this
software under copyright law.

THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND,
EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF
MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT.
IN NO EVENT SHALL THE AUTHORS BE LIABLE FOR ANY CLAIM, DAMAGES OR
OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE,
ARISING FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR
OTHER DEALINGS IN THE SOFTWARE.

For more information, please refer to <https://unlicense.org>
```