### PR TITLE
Added SetMenuIcon to FuryToggle Public API

### DIFF
--- a/com.vrcfury.vrcfury/PublicApi/Components/FuryToggle.cs
+++ b/com.vrcfury.vrcfury/PublicApi/Components/FuryToggle.cs
@@ -20,6 +20,11 @@ namespace com.vrcfury.api.Components {
             c.name = path;
         }
 
+        public void SetMenuIcon(Texture2D icon) {
+            c.enableIcon = true;
+            c.icon = icon;
+        }
+
         public void SetSlider(bool slider = true) {
             c.slider = slider;
         }


### PR DESCRIPTION
I use this in a script I made, and my ethics advisor says I am morally compelled to share this unique and special innovation in the event it's useful for others.

I didn't want to, given the incredible competitive advantage it offers, but he delivered a powerful and emotional speech at just the right moment. Because of this, everyone would be pretty mad at me if I didn't share. I have since fired the advisor, to prevent similar incidents, but the impacts of the speech remain and so here is this pull request.