### PR TITLE
Fix: handle null transitions and empty conditions in RewriteConditions

### DIFF
--- a/com.vrcfury.vrcfury/Editor/VF/Utils/AnimatorTransitionBaseExtensions.cs
+++ b/com.vrcfury.vrcfury/Editor/VF/Utils/AnimatorTransitionBaseExtensions.cs
@@ -4,54 +4,72 @@ using System.Linq;
 using UnityEditor.Animations;
 using VF.Inspector;
 
-namespace VF.Utils {
-    internal static class AnimatorTransitionBaseExtensions {
+namespace VF.Utils
+{
+    internal static class AnimatorTransitionBaseExtensions
+    {
         /**
          * Updating conditions is expensive because it calls AnimatorController.OnInvalidateAnimatorController
          * So only do if it something actually changes.
          */
-        public static AnimatorTransitionBase[] RewriteConditions(this AnimatorTransitionBase transition, Func<AnimatorCondition, Rewritten> rewrite) {
+        public static AnimatorTransitionBase[] RewriteConditions(
+        this AnimatorTransitionBase transition,
+        Func<AnimatorCondition, Rewritten> rewrite)
+        {
             var updated = false;
-            var andOr = transition.conditions.SelectMany(condition => {
-                var rewritten = rewrite(condition);
-                if (rewritten.andOr.Length != 1 || rewritten.andOr[0].Length != 1 || !rewritten.andOr[0][0].Equals(condition)) {
-                    updated = true;
-                }
-                return rewritten.andOr;
-            }).ToArray();
-            if (!updated) {
-                return new[] { transition };
-            }
 
-            return andOr.CrossProduct()
-                .Select(and => {
+            /* 
+             * Guard-clauses for when a condition or a transition is null and not an empty array, 
+             * can be caused by a script generated .controller with broken transitions 
+             */
+             
+            if (transition == null)
+                return Array.Empty<AnimatorTransitionBase>();
+            var conds = transition.conditions ?? Array.Empty<AnimatorCondition>();
+
+            var andOr = conds.SelectMany(condition =>
+                {
+                    var rewritten = rewrite(condition);
+                    if (rewritten.andOr.Length != 1 || rewritten.andOr[0].Length != 1 || !rewritten.andOr[0][0].Equals(condition))
+                        updated = true;
+                    return rewritten.andOr;
+                }).ToArray();
+
+            if (!updated)
+                return new[] { transition };
+
+            return andOr.CrossProduct().Select(and =>
+                {
                     var clone = transition.Clone();
                     clone.conditions = and.ToArray();
                     return clone;
-                })
-                .ToArray();
+                }).ToArray();
         }
 
-        private static readonly AnimatorCondition True = new AnimatorCondition() {
+
+        private static readonly AnimatorCondition True = new AnimatorCondition()
+        {
             parameter = VFBlendTreeDirect.AlwaysOneParam,
             mode = AnimatorConditionMode.Greater,
             threshold = 0
         };
-        
-        private static readonly AnimatorCondition False = new AnimatorCondition() {
+
+        private static readonly AnimatorCondition False = new AnimatorCondition()
+        {
             parameter = VFBlendTreeDirect.AlwaysOneParam,
             mode = AnimatorConditionMode.Less,
             threshold = 0
         };
 
-        public class Rewritten {
-            public AnimatorCondition[][] andOr = {};
+        public class Rewritten
+        {
+            public AnimatorCondition[][] andOr = { };
 
             public static implicit operator Rewritten(AnimatorCondition[] and) => And(and);
             public static implicit operator Rewritten(AnimatorCondition single) => And(single);
             public static implicit operator Rewritten(bool single) => And(single ? True : False);
-            public static Rewritten Or(params AnimatorCondition[] or) => new Rewritten { andOr = new [] { or } };
-            public static Rewritten And(params AnimatorCondition[] and) => new Rewritten { andOr = and.Select(o => new [] { o }).ToArray() };
+            public static Rewritten Or(params AnimatorCondition[] or) => new Rewritten { andOr = new[] { or } };
+            public static Rewritten And(params AnimatorCondition[] and) => new Rewritten { andOr = and.Select(o => new[] { o }).ToArray() };
         }
     }
 }


### PR DESCRIPTION
This fixes a NullReferenceException in AnimatorTransitionBaseExtensions.RewriteConditions that occurs when transition is null or when the conditions array is null or empty, by returning early or initializing an Empty Array.

It happens in script-generated animator controllers (entry/exit transitions, sub-state machines) where Unity doesn't always initialize conditions.

I understand the project is tightly maintained, but this is a critical edge-case fix with zero behavioral impact on normal usage. It only prevents crashes in malformed controller data.

---------------------------------------------------------------------------

The changes made in this contribution are free and unencumbered software
released into the public domain.

Anyone is free to copy, modify, publish, use, compile, sell, or
distribute this software, either in source code form or as a compiled
binary, for any purpose, commercial or non-commercial, and by any
means.

In jurisdictions that recognize copyright laws, the author or authors
of this software dedicate any and all copyright interest in the
software to the public domain. We make this dedication for the benefit
of the public at large and to the detriment of our heirs and
successors. We intend this dedication to be an overt act of
relinquishment in perpetuity of all present and future rights to this
software under copyright law.

THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND,
EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF
MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT.
IN NO EVENT SHALL THE AUTHORS BE LIABLE FOR ANY CLAIM, DAMAGES OR
OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE,
ARISING FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR
OTHER DEALINGS IN THE SOFTWARE.

For more information, please refer to <https://unlicense.org>