### PR TITLE
Allow socket parameters to be set as global (no prefix)

### DIFF
--- a/com.vrcfury.vrcfury/Editor/VF/Inspector/VRCFuryHapticSocketEditor.cs
+++ b/com.vrcfury.vrcfury/Editor/VF/Inspector/VRCFuryHapticSocketEditor.cs
@@ -59,6 +59,7 @@ namespace VF.Inspector {
             container.Add(VRCFuryEditorUtils.RefreshOnChange(() => {
                 if (!addMenuItemProp.boolValue) return new VisualElement();
                 var toggles = VRCFuryEditorUtils.Section("Menu Toggle", "A menu item will be created for this socket");
+                toggles.Add(VRCFuryEditorUtils.BetterProp(serializedObject.FindProperty("useGlobalMenuParameter"), "Use global parameter (no prefix)", tooltip: "When enabled, the toggle parameter will not include the usual VRCFury prefix. This can help share a single parameter name across features/avatars. Be careful to avoid name conflicts."));
                 toggles.Add(VRCFuryEditorUtils.BetterProp(serializedObject.FindProperty("enableAuto"), "Include in Auto selection?", tooltip: "If checked, this socket will be eligible to be chosen during 'Auto Mode', which is an option in your menu which will automatically enable the socket nearest to a plug."));
                 toggles.Add(VRCFuryEditorUtils.BetterProp(serializedObject.FindProperty("menuIcon"), "Menu Icon", tooltip: "Override the menu icon used for this socket's individual toggle. Looking to move or change the icon of the main SPS menu? Add a VRCFury 'SPS Options' component to the avatar root."));
                 return toggles;

--- a/com.vrcfury.vrcfury/Editor/VF/Service/BakeHapticSocketsService.cs
+++ b/com.vrcfury.vrcfury/Editor/VF/Service/BakeHapticSocketsService.cs
@@ -97,7 +97,8 @@ namespace VF.Service {
                     
                     VFABool toggleParam = null;
                     if (socket.addMenuItem) {
-                        toggleParam = fx.NewBool(name, synced: true, saved: saved);
+                        var usePrefix = !socket.useGlobalMenuParameter;
+                        toggleParam = fx.NewBool(name, synced: true, saved: saved, usePrefix: usePrefix);
                         var icon = socket.menuIcon?.Get();
                         menu.NewMenuToggle($"{spsOptions.GetMenuPath()}/{name}", toggleParam, icon: icon);
                     }

--- a/com.vrcfury.vrcfury/Runtime/VF/Component/VRCFuryHapticSocket.cs
+++ b/com.vrcfury.vrcfury/Runtime/VF/Component/VRCFuryHapticSocket.cs
@@ -26,6 +26,8 @@ namespace VF.Component {
         public float length;
         public bool unitsInMeters = true;
         public bool addMenuItem = true;
+    // If true, the menu toggle parameter will be created without a prefix (as a global parameter)
+    public bool useGlobalMenuParameter = false;
         public GuidTexture2d menuIcon;
         public bool enableAuto = true;
         public Vector3 position;


### PR DESCRIPTION
I wanted to be able to interact with my sps parameters using parameter drivers in my fx layer, so I made it so the sps socket parameters can be set as global
