### PR TITLE
More control over anchor override fix

### DIFF
--- a/com.vrcfury.vrcfury/Editor/VF/Actions/WorldDropActionBuilder.cs
+++ b/com.vrcfury.vrcfury/Editor/VF/Actions/WorldDropActionBuilder.cs
@@ -19,7 +19,8 @@ namespace VF.Actions {
         public AnimationClip Build(WorldDropAction model, string actionName) {
             var onClip = NewClip();
             if (model.obj != null && worldDropService != null) {
-                model.obj.AddComponent<VRCFuryKeepAnchorOverride>();
+                var keepAnchorOverride = model.obj.AddComponent<VRCFuryKeepAnchorOverride>();
+                keepAnchorOverride.isWorldDrop = true;
                 var param = worldDropService.Add(model.obj, actionName);
                 // Doing this through an AAP will delay the drop by one frame, but that's exactly what we want
                 // because we want Turn On toggles to activate first (to reset the position) before the drop happens!

--- a/com.vrcfury.vrcfury/Editor/VF/Actions/WorldDropActionBuilder.cs
+++ b/com.vrcfury.vrcfury/Editor/VF/Actions/WorldDropActionBuilder.cs
@@ -2,6 +2,7 @@
 using UnityEditor;
 using UnityEngine;
 using UnityEngine.UIElements;
+using VF.Component;
 using VF.Feature.Base;
 using VF.Injector;
 using VF.Inspector;
@@ -14,10 +15,11 @@ namespace VF.Actions {
     [FeatureHideTitleInEditor]
     internal class WorldDropActionBuilder : ActionBuilder<WorldDropAction> {
         [VFAutowired] [CanBeNull] private readonly WorldDropService worldDropService;
-        
+
         public AnimationClip Build(WorldDropAction model, string actionName) {
             var onClip = NewClip();
             if (model.obj != null && worldDropService != null) {
+                model.obj.AddComponent<VRCFuryKeepAnchorOverride>();
                 var param = worldDropService.Add(model.obj, actionName);
                 // Doing this through an AAP will delay the drop by one frame, but that's exactly what we want
                 // because we want Turn On toggles to activate first (to reset the position) before the drop happens!
@@ -25,7 +27,7 @@ namespace VF.Actions {
             }
             return onClip;
         }
-        
+
         [FeatureEditor]
         public static VisualElement Editor(SerializedProperty prop) {
             var row = new VisualElement().Row();

--- a/com.vrcfury.vrcfury/Editor/VF/Feature/AnchorOverrideFixBuilder.cs
+++ b/com.vrcfury.vrcfury/Editor/VF/Feature/AnchorOverrideFixBuilder.cs
@@ -24,7 +24,7 @@ namespace VF.Feature {
                 root = VRCFArmatureUtils.FindBoneOnArmatureOrException(avatarObject, HumanBodyBones.Hips);
             }
             foreach (var skin in avatarObject.GetComponentsInSelfAndChildren<Renderer>()) {
-                if (skin.probeAnchor == null) skin.probeAnchor = root;
+                skin.probeAnchor = root;
             }
         }
         
@@ -32,8 +32,8 @@ namespace VF.Feature {
         public static VisualElement Editor() {
             var content = new VisualElement();
             content.Add(VRCFuryEditorUtils.Info(
-                "This feature will set the anchor override for every mesh on your avatar to your chest (unless the " +
-                "mesh already has one). This will prevent different meshes from being lit differently on your body."));
+                "This feature will set the anchor override for every mesh on your avatar to your chest. " +
+                "This will prevent different meshes from being lit differently on your body."));
             return content;
         }
     }

--- a/com.vrcfury.vrcfury/Editor/VF/Feature/AnchorOverrideFixBuilder.cs
+++ b/com.vrcfury.vrcfury/Editor/VF/Feature/AnchorOverrideFixBuilder.cs
@@ -1,4 +1,5 @@
 using System;
+using System.Linq;
 using UnityEditor;
 using UnityEngine;
 using UnityEngine.UIElements;
@@ -8,6 +9,7 @@ using VF.Feature.Base;
 using VF.Injector;
 using VF.Inspector;
 using VF.Model.Feature;
+using VF.Utils;
 
 namespace VF.Feature {
     [FeatureTitle("Anchor Override Fix")]
@@ -25,18 +27,39 @@ namespace VF.Feature {
                 root = VRCFArmatureUtils.FindBoneOnArmatureOrException(avatarObject, HumanBodyBones.Hips);
             }
             foreach (var skin in avatarObject.GetComponentsInSelfAndChildren<Renderer>()) {
-                if (((VFGameObject)skin.gameObject).GetComponentInSelfOrParent<VRCFuryKeepAnchorOverride>() == null) {
-                    skin.probeAnchor = root;
-                }
+                if (model.ignoreExisting && skin.probeAnchor != null) continue;
+                var keepAnchorOverrides = ((VFGameObject)skin.gameObject).GetComponentsInSelfAndParents<VRCFuryKeepAnchorOverride>();
+                if (model.ignoreWorldDrops && keepAnchorOverrides.Any(k => k.isWorldDrop)) continue;
+                if (keepAnchorOverrides.Any(k => !k.isWorldDrop)) continue;
+
+                skin.probeAnchor = root;
             }
         }
 
         [FeatureEditor]
-        public static VisualElement Editor() {
+        public static VisualElement Editor(SerializedProperty prop) {
             var content = new VisualElement();
             content.Add(VRCFuryEditorUtils.Info(
                 "This feature will set the anchor override for every mesh on your avatar to your chest. " +
                 "This will prevent different meshes from being lit differently on your body."));
+
+            var adv = new Foldout {
+                text = "Advanced Options",
+                value = false
+            }.AddTo(content);
+
+            adv.Add(VRCFuryEditorUtils.Prop(
+                prop.FindPropertyRelative("ignoreExisting"),
+                "Only change empty anchor overrides",
+                tooltip: "Before this component existed, some assets used random anchor overrides. " +
+                "They might look incorrect if this option is turned on."
+            ));
+
+            adv.Add(VRCFuryEditorUtils.Prop(
+                prop.FindPropertyRelative("ignoreWorldDrops"),
+                "Ignore VRCFury world drops"
+            ));
+
             return content;
         }
     }

--- a/com.vrcfury.vrcfury/Editor/VF/Feature/AnchorOverrideFixBuilder.cs
+++ b/com.vrcfury.vrcfury/Editor/VF/Feature/AnchorOverrideFixBuilder.cs
@@ -3,6 +3,7 @@ using UnityEditor;
 using UnityEngine;
 using UnityEngine.UIElements;
 using VF.Builder;
+using VF.Component;
 using VF.Feature.Base;
 using VF.Injector;
 using VF.Inspector;
@@ -24,10 +25,12 @@ namespace VF.Feature {
                 root = VRCFArmatureUtils.FindBoneOnArmatureOrException(avatarObject, HumanBodyBones.Hips);
             }
             foreach (var skin in avatarObject.GetComponentsInSelfAndChildren<Renderer>()) {
-                skin.probeAnchor = root;
+                if (((VFGameObject)skin.gameObject).GetComponentInSelfOrParent<VRCFuryKeepAnchorOverride>() == null) {
+                    skin.probeAnchor = root;
+                }
             }
         }
-        
+
         [FeatureEditor]
         public static VisualElement Editor() {
             var content = new VisualElement();

--- a/com.vrcfury.vrcfury/Editor/VF/Feature/AnchorOverrideFixBuilder.cs
+++ b/com.vrcfury.vrcfury/Editor/VF/Feature/AnchorOverrideFixBuilder.cs
@@ -24,7 +24,7 @@ namespace VF.Feature {
                 root = VRCFArmatureUtils.FindBoneOnArmatureOrException(avatarObject, HumanBodyBones.Hips);
             }
             foreach (var skin in avatarObject.GetComponentsInSelfAndChildren<Renderer>()) {
-                skin.probeAnchor = root;
+                if (skin.probeAnchor == null) skin.probeAnchor = root;
             }
         }
         
@@ -32,8 +32,8 @@ namespace VF.Feature {
         public static VisualElement Editor() {
             var content = new VisualElement();
             content.Add(VRCFuryEditorUtils.Info(
-                "This feature will set the anchor override for every mesh on your avatar to your chest. " +
-                "This will prevent different meshes from being lit differently on your body."));
+                "This feature will set the anchor override for every mesh on your avatar to your chest (unless the " +
+                "mesh already has one). This will prevent different meshes from being lit differently on your body."));
             return content;
         }
     }

--- a/com.vrcfury.vrcfury/Editor/VF/Inspector/VRCFuryKeepAnchorOverrideEditor.cs
+++ b/com.vrcfury.vrcfury/Editor/VF/Inspector/VRCFuryKeepAnchorOverrideEditor.cs
@@ -1,0 +1,17 @@
+using UnityEditor;
+using UnityEngine.UIElements;
+using VF.Component;
+
+namespace VF.Inspector {
+    [CustomEditor(typeof(VRCFuryKeepAnchorOverride), true)]
+    internal class VRCFKeepAnchorOverrideEditor : VRCFuryComponentEditor<VRCFuryKeepAnchorOverride> {
+        protected override VisualElement CreateEditor(SerializedObject serializedObject, VRCFuryKeepAnchorOverride target) {
+            var container = new VisualElement();
+						container.Add(VRCFuryEditorUtils.Info(
+							"Any renderers under this component will be unaffected by the Anchor Override Fix component. " +
+							"This is intended for assets that are 'separate' from the avatar like world drops or followers."
+						));
+            return container;
+        }
+    }
+}

--- a/com.vrcfury.vrcfury/Editor/VF/Inspector/VRCFuryKeepAnchorOverrideEditor.cs.meta
+++ b/com.vrcfury.vrcfury/Editor/VF/Inspector/VRCFuryKeepAnchorOverrideEditor.cs.meta
@@ -1,0 +1,11 @@
+fileFormatVersion: 2
+guid: 582de65d7919fa845841f38174d4edbe
+MonoImporter:
+  externalObjects: {}
+  serializedVersion: 2
+  defaultReferences: []
+  executionOrder: 0
+  icon: {instanceID: 0}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/com.vrcfury.vrcfury/Runtime/VF/Component/VRCFuryKeepAnchorOverride.cs
+++ b/com.vrcfury.vrcfury/Runtime/VF/Component/VRCFuryKeepAnchorOverride.cs
@@ -1,0 +1,7 @@
+using UnityEngine;
+
+namespace VF.Component {
+    [AddComponentMenu("VRCFury/Keep Anchor Override (VRCFury)")]
+    internal class VRCFuryKeepAnchorOverride : VRCFuryComponent {
+    }
+}

--- a/com.vrcfury.vrcfury/Runtime/VF/Component/VRCFuryKeepAnchorOverride.cs
+++ b/com.vrcfury.vrcfury/Runtime/VF/Component/VRCFuryKeepAnchorOverride.cs
@@ -3,5 +3,6 @@ using UnityEngine;
 namespace VF.Component {
     [AddComponentMenu("VRCFury/Keep Anchor Override (VRCFury)")]
     internal class VRCFuryKeepAnchorOverride : VRCFuryComponent {
+        public bool isWorldDrop = false;
     }
 }

--- a/com.vrcfury.vrcfury/Runtime/VF/Component/VRCFuryKeepAnchorOverride.cs.meta
+++ b/com.vrcfury.vrcfury/Runtime/VF/Component/VRCFuryKeepAnchorOverride.cs.meta
@@ -1,0 +1,11 @@
+fileFormatVersion: 2
+guid: 459abecaa7c8a0648872e953f5b88338
+MonoImporter:
+  externalObjects: {}
+  serializedVersion: 2
+  defaultReferences: []
+  executionOrder: 0
+  icon: {instanceID: 0}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/com.vrcfury.vrcfury/Runtime/VF/Model/Feature/AnchorOverrideFix2.cs
+++ b/com.vrcfury.vrcfury/Runtime/VF/Model/Feature/AnchorOverrideFix2.cs
@@ -3,5 +3,7 @@
 namespace VF.Model.Feature {
     [Serializable]
     internal class AnchorOverrideFix2 : NewFeatureModel {
+        public bool ignoreExisting = false;
+        public bool ignoreWorldDrops = true;
     }
 }


### PR DESCRIPTION
This helps creators prevent world drop or follower assets from acting weird even if someone's using this component.
```
The changes made in this contribution are free and unencumbered software
released into the public domain.

Anyone is free to copy, modify, publish, use, compile, sell, or
distribute this software, either in source code form or as a compiled
binary, for any purpose, commercial or non-commercial, and by any
means.

In jurisdictions that recognize copyright laws, the author or authors
of this software dedicate any and all copyright interest in the
software to the public domain. We make this dedication for the benefit
of the public at large and to the detriment of our heirs and
successors. We intend this dedication to be an overt act of
relinquishment in perpetuity of all present and future rights to this
software under copyright law.

THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND,
EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF
MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT.
IN NO EVENT SHALL THE AUTHORS BE LIABLE FOR ANY CLAIM, DAMAGES OR
OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE,
ARISING FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR
OTHER DEALINGS IN THE SOFTWARE.

For more information, please refer to <https://unlicense.org>
```