### PR TITLE
Global collider overrides

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -90,6 +90,8 @@ For more information, please refer to <https://unlicense.org>
   * Prevented SPS toggle from disabling SPS autorig physbone
   * Set the Editor Test Copy's Animator controller to the generated FX layer
   * Added drop-in box for quickly setting bones in Armature Link
+* Purpzie
+  * Added global collider overrides
 * Raphiiko
   * Added global parameters for Toggles
 * sentfromspacevr

--- a/com.vrcfury.vrcfury/Editor/VF/Inspector/VRCFGlobalColliderEditor.cs
+++ b/com.vrcfury.vrcfury/Editor/VF/Inspector/VRCFGlobalColliderEditor.cs
@@ -26,13 +26,17 @@ namespace VF.Inspector {
             
             container.Add(VRCFuryEditorUtils.Info(
                 "This will add a collider which can be used to interact with other player's physbones and trigger haptics.\n\n" +
-                "Note: This steals one of the colliders from your avatar's fingers. If you don't need to interact with physbones, you can use" +
-                " a VRCFury Haptic Touch Sender instead, which can only trigger haptics and does not steal a finger."
+                "Note: This steals one of the colliders from your avatar's fingers by default. If you don't need to interact with physbones," +
+                " you can use a VRCFury Haptic Touch Sender instead, which can only trigger haptics and does  not steal a finger."
             ));
-            
             container.Add(VRCFuryEditorUtils.Prop(serializedObject.FindProperty("rootTransform"), "Root Transform Override"));
             container.Add(VRCFuryEditorUtils.Prop(serializedObject.FindProperty("radius"), "Radius"));
             container.Add(VRCFuryEditorUtils.Prop(serializedObject.FindProperty("height"), "Height"));
+            container.Add(VRCFuryEditorUtils.Prop(
+                serializedObject.FindProperty("colliderOverride"),
+                label: "Collider Override",
+                tooltip: "Only hand and finger colliders affect physbones, but other colliders are available here for advanced setups."
+            ));
 
             return container;
         }

--- a/com.vrcfury.vrcfury/Editor/VF/Service/BakeGlobalCollidersService.cs
+++ b/com.vrcfury.vrcfury/Editor/VF/Service/BakeGlobalCollidersService.cs
@@ -139,7 +139,13 @@ namespace VF.Service {
                     objOverride = childObj,
                     onlyIfChildOfHead = true
                 });
-                if (globalContact.height <= globalContact.radius * 2) {
+                if (!IsFinger(bone)) {
+                    collider.transform = childObj;
+                    collider.radius = globalContact.radius;
+                    collider.height = globalContact.height;
+                    // Non-fingers need this for some reason...?
+                    collider.rotation = Quaternion.AngleAxis(90, Vector3.right);
+                } else if (globalContact.height <= globalContact.radius * 2) {
                     // It's a sphere
                     collider.transform = childObj;
                     collider.height = 0;
@@ -192,6 +198,11 @@ namespace VF.Service {
                 VRCFuryGlobalCollider.Override.RightFingerMiddle
             };
             return autoFingers.Contains(o);
+        }
+
+        private static bool IsFinger(HumanBodyBones bone) {
+            string name = bone.ToString();
+            return name.Contains("Proximal") || name.Contains("Intermediate") || name.Contains("Distal");
         }
     }
 }

--- a/com.vrcfury.vrcfury/Runtime/VF/Component/VRCFuryGlobalCollider.cs
+++ b/com.vrcfury.vrcfury/Runtime/VF/Component/VRCFuryGlobalCollider.cs
@@ -3,9 +3,29 @@ using UnityEngine;
 namespace VF.Component {
     [AddComponentMenu("VRCFury/Global Collider (VRCFury)")]
     internal class VRCFuryGlobalCollider : VRCFuryComponent {
+        // subset of HumanBodyBones in VRCAvatarDescriptor order
+        public enum Override {
+            Auto = -1,
+            Head = HumanBodyBones.Head,
+            Torso = HumanBodyBones.Chest,
+            LeftHand = HumanBodyBones.LeftHand,
+            RightHand = HumanBodyBones.RightHand,
+            LeftFoot = HumanBodyBones.LeftToes,
+            RightFoot = HumanBodyBones.RightToes,
+            LeftFingerIndex = HumanBodyBones.LeftIndexIntermediate,
+            RightFingerIndex = HumanBodyBones.RightIndexIntermediate,
+            LeftFingerMiddle = HumanBodyBones.LeftMiddleIntermediate,
+            RightFingerMiddle = HumanBodyBones.RightMiddleIntermediate,
+            LeftFingerRing = HumanBodyBones.LeftRingIntermediate,
+            RightFingerRing = HumanBodyBones.RightRingIntermediate,
+            LeftFingerLittle = HumanBodyBones.LeftLittleIntermediate,
+            RightFingerLittle = HumanBodyBones.RightLittleIntermediate
+        }
+
         public float radius = 0.1f;
         public float height = 0;
         public Transform rootTransform;
+        public Override colliderOverride = Override.Auto;
 
         public Transform GetTransform() {
             return rootTransform != null ? rootTransform : transform;


### PR DESCRIPTION
It defaults to the current behavior that only steals fingers and in a specific order.

This can be used to change where you grab physbones from (example: with your mouth) by moving a hand collider, or to move default contacts around advanced avatars where the humanoid doesn't match up.

<img width="563" height="631" alt="image" src="https://github.com/user-attachments/assets/e615d6b3-5141-491e-b4f1-a80e04f16cda" />

```
The changes made in this contribution are free and unencumbered software
released into the public domain.

Anyone is free to copy, modify, publish, use, compile, sell, or
distribute this software, either in source code form or as a compiled
binary, for any purpose, commercial or non-commercial, and by any
means.

In jurisdictions that recognize copyright laws, the author or authors
of this software dedicate any and all copyright interest in the
software to the public domain. We make this dedication for the benefit
of the public at large and to the detriment of our heirs and
successors. We intend this dedication to be an overt act of
relinquishment in perpetuity of all present and future rights to this
software under copyright law.

THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND,
EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF
MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT.
IN NO EVENT SHALL THE AUTHORS BE LIABLE FOR ANY CLAIM, DAMAGES OR
OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE,
ARISING FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR
OTHER DEALINGS IN THE SOFTWARE.

For more information, please refer to <https://unlicense.org>
```