### PR TITLE
Move collider (Attempt 2)

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -90,6 +90,8 @@ For more information, please refer to <https://unlicense.org>
   * Prevented SPS toggle from disabling SPS autorig physbone
   * Set the Editor Test Copy's Animator controller to the generated FX layer
   * Added drop-in box for quickly setting bones in Armature Link
+* Purpzie
+  * Added moveable colliders
 * Raphiiko
   * Added global parameters for Toggles
 * sentfromspacevr

--- a/com.vrcfury.vrcfury/Editor/VF/Feature/MoveColliderBuilder.cs
+++ b/com.vrcfury.vrcfury/Editor/VF/Feature/MoveColliderBuilder.cs
@@ -1,0 +1,32 @@
+using UnityEditor;
+using UnityEngine;
+using UnityEngine.UIElements;
+using VF.Feature.Base;
+using VF.Inspector;
+using VF.Model.Feature;
+
+namespace VF.Feature
+{
+	[FeatureTitle("Move Collider")]
+	[FeatureRootOnly]
+	internal class MoveColliderBuilder : FeatureBuilder<MoveCollider> {
+		[FeatureEditor]
+		public static VisualElement Editor(SerializedProperty prop) {
+			var content = new VisualElement();
+			content.Add(VRCFuryEditorUtils.Info(
+				"This moves a default collider (like head, torso, etc) to a different object than normal." +
+				" There can only be one of each type on the avatar.\n\nMoving a hand collider will also" +
+				" move where you grab physbones from."
+			));
+			content.Add(VRCFuryEditorUtils.Prop(prop.FindPropertyRelative("avatarCollider"), "Collider"));
+			content.Add(VRCFuryEditorUtils.Prop(prop.FindPropertyRelative("rootTransform"), "Root Transform"));
+			content.Add(VRCFuryEditorUtils.Prop(prop.FindPropertyRelative("radius"), "Radius"));
+			content.Add(VRCFuryEditorUtils.Prop(prop.FindPropertyRelative("height"), "Height"));
+			return content;
+		}
+
+		public Transform GetTransform() {
+			return model.rootTransform != null ? model.rootTransform : featureBaseObject;
+		}
+	}
+}

--- a/com.vrcfury.vrcfury/Editor/VF/Feature/MoveColliderBuilder.cs.meta
+++ b/com.vrcfury.vrcfury/Editor/VF/Feature/MoveColliderBuilder.cs.meta
@@ -1,0 +1,11 @@
+fileFormatVersion: 2
+guid: 31c6f4bbe8a45334cb43cbdaca91b994
+MonoImporter:
+  externalObjects: {}
+  serializedVersion: 2
+  defaultReferences: []
+  executionOrder: 0
+  icon: {instanceID: 0}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/com.vrcfury.vrcfury/Editor/VF/Inspector/VRCFuryEditor.cs
+++ b/com.vrcfury.vrcfury/Editor/VF/Inspector/VRCFuryEditor.cs
@@ -60,13 +60,13 @@ namespace VF.Inspector {
             }
 
             foreach (var c in vf.GetAllFeatures().OfType<MoveCollider>()) {
-                var transform = c.rootTransform != null ? c.rootTransform : (Transform)vf.owner();
-                var worldHeight = c.height * vf.owner().worldScale.x;
-                var worldRadius = c.radius * vf.owner().worldScale.x;
+                VFGameObject obj = c.rootTransform != null ? c.rootTransform : vf.owner();
+                var worldHeight = c.height * obj.worldScale.x;
+                var worldRadius = c.radius * obj.worldScale.x;
 
                 VRCFuryGizmoUtils.DrawCapsule(
-                    transform.position,
-                    transform.rotation * Quaternion.Euler(90, 0, 0),
+                    obj.worldPosition,
+                    obj.worldRotation * Quaternion.Euler(90, 0, 0),
                     worldHeight,
                     worldRadius,
                     Color.green

--- a/com.vrcfury.vrcfury/Editor/VF/Inspector/VRCFuryEditor.cs
+++ b/com.vrcfury.vrcfury/Editor/VF/Inspector/VRCFuryEditor.cs
@@ -34,7 +34,7 @@ namespace VF.Inspector {
                 });
             }
         }
-        
+
         [DrawGizmo(GizmoType.Selected | GizmoType.Active | GizmoType.InSelectionHierarchy)]
         static void DrawGizmo(VRCFury vf, GizmoType gizmoType) {
             foreach (var g in vf.GetAllFeatures().OfType<Gizmo>()) {
@@ -57,6 +57,20 @@ namespace VF.Inspector {
                 if (g.sphereRadius > 0) {
                     VRCFuryGizmoUtils.DrawSphere(worldPos, g.sphereRadius * vf.owner().worldScale.x, Color.red);
                 }
+            }
+
+            foreach (var c in vf.GetAllFeatures().OfType<MoveCollider>()) {
+                var transform = c.rootTransform != null ? c.rootTransform : (Transform)vf.owner();
+                var worldHeight = c.height * vf.owner().worldScale.x;
+                var worldRadius = c.radius * vf.owner().worldScale.x;
+
+                VRCFuryGizmoUtils.DrawCapsule(
+                    transform.position,
+                    transform.rotation * Quaternion.Euler(90, 0, 0),
+                    worldHeight,
+                    worldRadius,
+                    Color.green
+                );
             }
         }
     }

--- a/com.vrcfury.vrcfury/Editor/VF/Service/BakeGlobalCollidersService.cs
+++ b/com.vrcfury.vrcfury/Editor/VF/Service/BakeGlobalCollidersService.cs
@@ -1,9 +1,11 @@
 using System;
 using System.Collections.Generic;
+using System.Linq;
 using UnityEngine;
 using VF.Builder;
 using VF.Builder.Exceptions;
 using VF.Component;
+using VF.Feature;
 using VF.Feature.Base;
 using VF.Injector;
 using VF.Model.Feature;
@@ -20,21 +22,20 @@ namespace VF.Service {
         public void Apply() {
 
             var globalContacts = avatarObject.GetComponentsInSelfAndChildren<VRCFuryGlobalCollider>();
-            if (globalContacts.Length == 0) return;
 
-            var fingers = new List<(HumanBodyBones, VRCAvatarDescriptor.ColliderConfig, Action<VRCAvatarDescriptor.ColliderConfig>)> {
-                ( HumanBodyBones.LeftRingIntermediate, avatar.collider_fingerRingL, c => avatar.collider_fingerRingL = c ),
-                ( HumanBodyBones.RightRingIntermediate, avatar.collider_fingerRingR, c => avatar.collider_fingerRingR = c ),
-                ( HumanBodyBones.LeftLittleIntermediate, avatar.collider_fingerLittleL, c => avatar.collider_fingerLittleL = c ),
-                ( HumanBodyBones.RightLittleIntermediate, avatar.collider_fingerLittleR, c => avatar.collider_fingerLittleR = c ),
-                ( HumanBodyBones.LeftMiddleIntermediate, avatar.collider_fingerMiddleL, c => avatar.collider_fingerMiddleL = c ),
-                ( HumanBodyBones.RightMiddleIntermediate, avatar.collider_fingerMiddleR, c => avatar.collider_fingerMiddleR = c ),
+            var fingers = new List<(HumanBodyBones, VRCAvatarDescriptor.ColliderConfig)> {
+                ( HumanBodyBones.LeftRingIntermediate, avatar.collider_fingerRingL ),
+                ( HumanBodyBones.RightRingIntermediate, avatar.collider_fingerRingR ),
+                ( HumanBodyBones.LeftLittleIntermediate, avatar.collider_fingerLittleL ),
+                ( HumanBodyBones.RightLittleIntermediate, avatar.collider_fingerLittleR ),
+                ( HumanBodyBones.LeftMiddleIntermediate, avatar.collider_fingerMiddleL ),
+                ( HumanBodyBones.RightMiddleIntermediate, avatar.collider_fingerMiddleR ),
             };
-            
+
             // Put unused fingers on the front of the list
             {
-                var unused = new List<(HumanBodyBones, VRCAvatarDescriptor.ColliderConfig, Action<VRCAvatarDescriptor.ColliderConfig>)>();
-                var used = new List<(HumanBodyBones, VRCAvatarDescriptor.ColliderConfig, Action<VRCAvatarDescriptor.ColliderConfig>)>();
+                var unused = new List<(HumanBodyBones, VRCAvatarDescriptor.ColliderConfig)>();
+                var used = new List<(HumanBodyBones, VRCAvatarDescriptor.ColliderConfig)>();
                 while (fingers.Count >= 2) {
                     var left = fingers[0];
                     var right = fingers[1];
@@ -53,23 +54,77 @@ namespace VF.Service {
                 fingers.AddRange(unused);
                 fingers.AddRange(used);
             }
-            
+
+            // Add all modified colliders to this list to be processed at the end
+            var finalColliders = new List<(HumanBodyBones, VRCAvatarDescriptor.ColliderConfig)>();
+
+            // Moved colliders should be processed before global colliders
+            foreach (var movedCollider in globals.allBuildersInRun.OfType<MoveColliderBuilder>()) {
+                var collider = VRCAvatarDescriptor.ColliderConfig.Create();
+                collider.transform = movedCollider.GetTransform();
+                collider.radius = movedCollider.model.radius;
+                collider.height = movedCollider.model.height;
+
+                // Prevent global colliders from using this bone
+                var bone = (HumanBodyBones)movedCollider.model.avatarCollider;
+                var fingerIndex = fingers.FindIndex(f => f.Item1 == bone);
+                if (fingerIndex != -1) fingers.RemoveAt(fingerIndex);
+
+                finalColliders.Add((bone, collider));
+            }
+
             if (globalContacts.Length > fingers.Count) {
                 throw new VRCFBuilderException("Too many VRCF global colliders are present on this avatar");
             }
 
-            var i = 0;
             foreach (var globalContact in globalContacts) {
-                PhysboneUtils.RemoveFromPhysbones(globalContact.owner());
+                var fingerBone = fingers[0].Item1;
+                fingers.RemoveAt(0);
+                var collider = VRCAvatarDescriptor.ColliderConfig.Create();
+                collider.transform = globalContact.GetTransform();
+                collider.radius = globalContact.radius;
+                collider.height = globalContact.height;
+                finalColliders.Add((fingerBone, collider));
+            }
 
-                var target = globalContact.GetTransform();
-                var finger = fingers[i].Item2;
-                var setFinger = fingers[i].Item3;
-                finger.isMirrored = false;
-                finger.state = VRCAvatarDescriptor.ColliderConfig.State.Custom;
-                finger.position = Vector3.zero;
-                finger.radius = globalContact.radius;
-                finger.rotation = Quaternion.identity;
+            // Prevent duplicate colliders of the same type by removing them from this
+            var colliderMap = new Dictionary<HumanBodyBones, Action<VRCAvatarDescriptor.ColliderConfig>>() {
+                { HumanBodyBones.Head, c => avatar.collider_head = c },
+                { HumanBodyBones.Chest, c => avatar.collider_torso = c },
+                { HumanBodyBones.LeftHand, c => avatar.collider_handL = c },
+                { HumanBodyBones.RightHand, c => avatar.collider_handR = c },
+                { HumanBodyBones.LeftToes, c => avatar.collider_footL = c },
+                { HumanBodyBones.RightToes, c => avatar.collider_footR = c },
+                { HumanBodyBones.LeftIndexIntermediate, c => avatar.collider_fingerIndexL = c },
+                { HumanBodyBones.RightIndexIntermediate, c => avatar.collider_fingerIndexR = c },
+                { HumanBodyBones.LeftMiddleIntermediate, c => avatar.collider_fingerMiddleL = c },
+                { HumanBodyBones.RightMiddleIntermediate, c => avatar.collider_fingerMiddleR = c },
+                { HumanBodyBones.LeftRingIntermediate, c => avatar.collider_fingerRingL = c },
+                { HumanBodyBones.RightRingIntermediate, c => avatar.collider_fingerRingR = c },
+                { HumanBodyBones.LeftLittleIntermediate, c => avatar.collider_fingerLittleL = c },
+                { HumanBodyBones.RightLittleIntermediate, c => avatar.collider_fingerLittleR = c }
+            };
+
+            foreach (var combined in finalColliders) {
+                var bone = combined.Item1;
+
+                if (!colliderMap.ContainsKey(bone)) {
+                    throw new VRCFBuilderException(
+                        "Only one " +
+                        ((MoveCollider.AvatarCollider)bone).ToString() + // nicer name
+                        " collider can be present on the avatar, but multiple were found"
+                    );
+                }
+                var setCollider = colliderMap[bone];
+                colliderMap.Remove(bone);
+
+                var collider = combined.Item2;
+                collider.isMirrored = false;
+                collider.state = VRCAvatarDescriptor.ColliderConfig.State.Custom;
+                collider.position = Vector3.zero;
+                collider.rotation = Quaternion.identity;
+
+                PhysboneUtils.RemoveFromPhysbones(collider.transform.gameObject);
 
                 // Vrchat places the capsule for fingers in a very strange place, but essentially it will:
                 // If collider length is 0, it will be a sphere centered on the set transform
@@ -77,46 +132,41 @@ namespace VF.Service {
                 // If collider length >= radius*2, it will be a capsule with one end attached to the set transform's parent,
                 //   facing the direction of the set transform.
 
-                var childObj = GameObjects.Create("GlobalContact", target);
+                var childObj = GameObjects.Create("Collider", collider.transform);
                 globals.addOtherFeature(new ShowInFirstPerson {
                     useObjOverride = true,
                     objOverride = childObj,
                     onlyIfChildOfHead = true
                 });
-                if (globalContact.height <= globalContact.radius * 2) {
+                collider.transform = childObj;
+
+                if (!IsFinger(bone)) {
+                    // Non-fingers need this for some reason...?
+                    collider.rotation = Quaternion.AngleAxis(90, Vector3.right);
+                } else if (collider.height <= collider.radius * 2) {
                     // It's a sphere
-                    finger.transform = childObj;
-                    finger.height = 0;
+                    collider.height = 0;
                 } else {
                     // It's a capsule
-                    childObj.localPosition = new Vector3(0, 0, -globalContact.height / 2);
+                    childObj.localPosition = new Vector3(0, 0, -collider.height / 2);
                     var directionObj = GameObjects.Create("Direction", childObj);
                     directionObj.localPosition = new Vector3(0, 0, 0.0001f);
-                    finger.transform = directionObj;
-                    finger.height = globalContact.height;
-                    
+                    collider.transform = directionObj;
+
                     // Turns out capsules work in game differently than they do in the vrcsdk in the editor
                     // They're even more weird. The capsules in game DO NOT include the endcaps in the height,
                     // and attach the end of the cylinder to the parent (not the endcap).
                     // This fixes them so they work properly in game:
                     var p = childObj.localPosition;
-                    p.z += finger.radius;
+                    p.z += collider.radius;
                     childObj.localPosition = p;
-                    finger.height -= finger.radius * 2;
+                    collider.height -= collider.radius * 2;
                 }
-                setFinger(finger);
-                i++;
-            }
-            if (i % 2 == 1) {
-                // If an odd number, disable the matching mirrored finger
-                var finger = fingers[i].Item2;
-                var setFinger = fingers[i].Item3;
-                finger.isMirrored = false;
-                finger.state = VRCAvatarDescriptor.ColliderConfig.State.Disabled;
-                setFinger(finger);
+
+                setCollider(collider);
             }
         }
-        
+
         private bool IsFingerCustom(HumanBodyBones bone, VRCAvatarDescriptor.ColliderConfig config) {
             if (config.state != VRCAvatarDescriptor.ColliderConfig.State.Custom) return false;
             VFGameObject configObj = config.transform;
@@ -131,6 +181,19 @@ namespace VF.Service {
             if (config.state == VRCAvatarDescriptor.ColliderConfig.State.Disabled) return false;
             if (VRCFArmatureUtils.FindBoneOnArmatureOrNull(avatarObject, bone) == null) return false;
             return true;
+        }
+
+        private static bool IsFinger(HumanBodyBones bone) {
+            return new[] {
+                HumanBodyBones.LeftIndexIntermediate,
+                HumanBodyBones.LeftMiddleIntermediate,
+                HumanBodyBones.RightIndexIntermediate,
+                HumanBodyBones.RightMiddleIntermediate,
+                HumanBodyBones.LeftRingIntermediate,
+                HumanBodyBones.RightRingIntermediate,
+                HumanBodyBones.LeftLittleIntermediate,
+                HumanBodyBones.RightLittleIntermediate
+            }.Contains(bone);
         }
     }
 }

--- a/com.vrcfury.vrcfury/Runtime/VF/Model/Feature/MoveCollider.cs
+++ b/com.vrcfury.vrcfury/Runtime/VF/Model/Feature/MoveCollider.cs
@@ -1,0 +1,30 @@
+using System;
+using UnityEngine;
+
+namespace VF.Model.Feature {
+	[Serializable]
+	internal class MoveCollider : NewFeatureModel {
+		// subset of HumanBodyBones in VRCAvatarDescriptor order
+		public enum AvatarCollider {
+			Head = HumanBodyBones.Head,
+			Torso = HumanBodyBones.Chest,
+			LeftHand = HumanBodyBones.LeftHand,
+			RightHand = HumanBodyBones.RightHand,
+			LeftFoot = HumanBodyBones.LeftToes,
+			RightFoot = HumanBodyBones.RightToes,
+			LeftFingerIndex = HumanBodyBones.LeftIndexIntermediate,
+			RightFingerIndex = HumanBodyBones.RightIndexIntermediate,
+			LeftFingerMiddle = HumanBodyBones.LeftMiddleIntermediate,
+			RightFingerMiddle = HumanBodyBones.RightMiddleIntermediate,
+			LeftFingerRing = HumanBodyBones.LeftRingIntermediate,
+			RightFingerRing = HumanBodyBones.RightRingIntermediate,
+			LeftFingerLittle = HumanBodyBones.LeftLittleIntermediate,
+			RightFingerLittle = HumanBodyBones.RightLittleIntermediate
+		}
+
+		public AvatarCollider avatarCollider = AvatarCollider.Head;
+		public float radius = 0.1f;
+		public float height = 0;
+		public Transform rootTransform;
+	}
+}

--- a/com.vrcfury.vrcfury/Runtime/VF/Model/Feature/MoveCollider.cs.meta
+++ b/com.vrcfury.vrcfury/Runtime/VF/Model/Feature/MoveCollider.cs.meta
@@ -1,0 +1,11 @@
+fileFormatVersion: 2
+guid: f96b903b6543bd24dbcf49552f5d77a1
+MonoImporter:
+  externalObjects: {}
+  serializedVersion: 2
+  defaultReferences: []
+  executionOrder: 0
+  icon: {instanceID: 0}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 


### PR DESCRIPTION
Reimplementation of #334 that separates it from global colliders and uses `[FeatureRootOnly]`.

- I saw the comments about finger colliders being weird. After testing ingame, it seems like those are the only ones that need special handling. Non-fingers just have extra rotation to match the gizmo.
- An error is thrown when two "move colliders" of the same type are on the avatar.
- If a finger collider is selected, it gets removed from the list of possible global colliders.
- At some point (not in this PR) I'd love to add a physbone grab range to the gizmo if you select a hand collider, but I haven't extensively tested how it gets placed ingame. Apparently it scales with the hand collider and always goes directly below it regardless of rotation.

<img width="435" height="198" alt="image" src="https://github.com/user-attachments/assets/389bd246-fa97-4cda-b205-80abfc99b44d" />

```
The changes made in this contribution are free and unencumbered software
released into the public domain.

Anyone is free to copy, modify, publish, use, compile, sell, or
distribute this software, either in source code form or as a compiled
binary, for any purpose, commercial or non-commercial, and by any
means.

In jurisdictions that recognize copyright laws, the author or authors
of this software dedicate any and all copyright interest in the
software to the public domain. We make this dedication for the benefit
of the public at large and to the detriment of our heirs and
successors. We intend this dedication to be an overt act of
relinquishment in perpetuity of all present and future rights to this
software under copyright law.

THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND,
EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF
MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT.
IN NO EVENT SHALL THE AUTHORS BE LIABLE FOR ANY CLAIM, DAMAGES OR
OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE,
ARISING FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR
OTHER DEALINGS IN THE SOFTWARE.

For more information, please refer to <https://unlicense.org>
```