### PR TITLE
fix parameter names for VRCRaycast

### DIFF
--- a/com.vrcfury.vrcfury/Editor-Avatars/Feature/FullControllerBuilder.cs
+++ b/com.vrcfury.vrcfury/Editor-Avatars/Feature/FullControllerBuilder.cs
@@ -127,7 +127,9 @@ namespace VF.Feature {
             }
 #if VRCSDK_HAS_VRCRAYCAST
             foreach (var raycast in GetBaseObject(model, featureBaseObject).GetComponentsInSelfAndChildren<VRCRaycast>()) {
-                if (rewrittenParams.ContainsKey(raycast.Parameter)) {
+                if (rewrittenParams.ContainsKey(raycast.Parameter + "_Hit") 
+                    || rewrittenParams.ContainsKey(raycast.Parameter + "_Ratio")
+                    || rewrittenParams.ContainsKey(raycast.Parameter + "_Distance")) {
                     raycast.Parameter = RewriteParamName(raycast.Parameter);
                 }
             }

--- a/com.vrcfury.vrcfury/Editor-Avatars/Service/Compressor/ParameterCompressorSolverService.cs
+++ b/com.vrcfury.vrcfury/Editor-Avatars/Service/Compressor/ParameterCompressorSolverService.cs
@@ -107,7 +107,9 @@ namespace VF.Service.Compressor {
             }
 #if VRCSDK_HAS_VRCRAYCAST
             foreach (var c in avatarObject.GetComponentsInSelfAndChildren<VRCRaycast>()) {
-                contactParams.Add(c.Parameter);
+                contactParams.Add(c.Parameter + "_Hit");
+                contactParams.Add(c.Parameter + "_Ratio");
+                contactParams.Add(c.Parameter + "_Distance");
             }
 #endif
             foreach (var c in avatarObject.GetComponentsInSelfAndChildren<VRCPhysBone>()) {


### PR DESCRIPTION
A simple quick fix I did during encountering an issue with VRCRaycast parameters not being renamed on build.

## License
The code is distributed under `The Unlicense`
```
The changes made in this contribution are free and unencumbered software
released into the public domain.

Anyone is free to copy, modify, publish, use, compile, sell, or
distribute this software, either in source code form or as a compiled
binary, for any purpose, commercial or non-commercial, and by any
means.

In jurisdictions that recognize copyright laws, the author or authors
of this software dedicate any and all copyright interest in the
software to the public domain. We make this dedication for the benefit
of the public at large and to the detriment of our heirs and
successors. We intend this dedication to be an overt act of
relinquishment in perpetuity of all present and future rights to this
software under copyright law.

THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND,
EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF
MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT.
IN NO EVENT SHALL THE AUTHORS BE LIABLE FOR ANY CLAIM, DAMAGES OR
OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE,
ARISING FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR
OTHER DEALINGS IN THE SOFTWARE.

For more information, please refer to <https://unlicense.org>
```